### PR TITLE
[UPD] schemas reformatributaria v02-4 + regeneração das bindings v03 (async/guias)

### DIFF
--- a/nfselib/paulistana/v03/ConsultaGuia.py
+++ b/nfselib/paulistana/v03/ConsultaGuia.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoConsultaNFe.py')
+#   ('-o', 'nfselib/paulistana/v03/ConsultaGuia.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoConsultaNFe_v02.xsd
+#   schemas/nfse/ConsultaGuia_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaNFe.py" schemas/nfse/PedidoConsultaNFe_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/ConsultaGuia.py" schemas/nfse/ConsultaGuia_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1008,6 +1008,24 @@ def _cast(typ, value):
 #
 # Start enum classes
 #
+class tpConsultaSituacaoGuias(str, Enum):
+    _1='1' # Guias pendentes de pagamento
+    _2='2' # Guias quitadas
+    _3='3' # Guias canceladas
+    _4='4' # Guias pendente de emissao
+
+
+class tpEmissaoGuia(str, Enum):
+    _1='1' # Guia de NFS-e emitidas
+    _2='2' # Guia de NFS-e recebidas (exceto rejeitadas)
+    _3='3' # Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)
+    _4='4' # Guia de NFS-e recebidas aceitas
+    _5='5' # Guia de NFS-e recebidas sem manifestação do tomador
+    _6='6' # Guia de NFS-e recebidas rejeitadas
+    _7='7' # Guia de NFTS emitidas
+    _8='8' # Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)
+
+
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
     
@@ -1162,6 +1180,53 @@ class tpReferencia(str, Enum):
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
 
 
+class tpSituacaoGuia(str, Enum):
+    """tpSituacaoGuia -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es da emiss
+    ã
+    o de guia ass
+    í
+    ncrona.
+    
+    """
+    SOLICITADA='solicitada' # Emissao solicitada (0).
+    INVALIDADA='invalidada' # Emissao invalidada (1).
+    VERIFICADA='verificada' # Emissao verificada (2).
+    PROCESSADA='processada' # Emissao processada (3).
+
+
+class tpSituacaoLote(str, Enum):
+    """tpSituacaoLote -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es do lote ass
+    í
+    ncrono.
+    
+    """
+    ENVIADO='enviado' # Lote enviado (0).
+    INVALIDADO='invalidado' # Lote invalidado (1).
+    VERIFICADO='verificado' # Lote verificado (2).
+    PROCESSADO='processado' # Lote processado (3).
+
+
+class tpStatusGuiaEnum(str, Enum):
+    _0='0' # Normal
+    _1='1' # Cancelada
+    _2='2' # Quitada
+    _3='3' # Aproveitada
+    _4='4' # Alterada
+    _5='5' # QuitadaPorRDT
+    _6='6' # QuitadaPorSubstituicao
+    _7='7' # QuitadaPorRetificacao
+
+
 class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
@@ -1211,31 +1276,226 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoConsultaNFe(GeneratedsSuper):
-    """PedidoConsultaNFe -- Schema utilizado para PEDIDO de consultas de NFS-e.
-    Este Schema XML
-    é
-    utilizado pelos prestadores de servi
-    ç
-    os consultarem NFS-e geradas por eles.
-    Cabecalho -- Cabe
-    ç
-    alho do pedido.
-    Detalhe -- Detalhe do pedido. Cada item de detalhe dever
-    á
-    conter a chave de uma NFS-e ou a chave de um RPS.
-    Signature -- Assinatura digital do contribuinte que gerou as NFS-e/RPS.
-    
-    """
+class PedidoConsultaGuia(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
-        MemberSpec_('Detalhe', 'DetalheType', 1, 0, {'maxOccurs': '50', 'minOccurs': '1', 'name': 'Detalhe', 'type': 'DetalheType'}, None),
-        MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
+        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('Incidencia', ['tpIncidencia', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Incidencia', 'type': 'xsd:string'}, None),
+        MemberSpec_('Situacao', ['tpConsultaSituacaoGuias', 'xsd:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Situacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('TipoEmissao', ['tpEmissaoGuia', 'xsd:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoEmissao', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Detalhe=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, CPFCNPJRemetente=None, InscricaoPrestador=None, Incidencia=None, Situacao=None, TipoEmissao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.CPFCNPJRemetente = CPFCNPJRemetente
+        self.CPFCNPJRemetente_nsprefix_ = None
+        self.InscricaoPrestador = InscricaoPrestador
+        self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        self.InscricaoPrestador_nsprefix_ = None
+        self.Incidencia = Incidencia
+        self.validate_tpIncidencia(self.Incidencia)
+        self.Incidencia_nsprefix_ = None
+        self.Situacao = Situacao
+        self.validate_tpConsultaSituacaoGuias(self.Situacao)
+        self.Situacao_nsprefix_ = None
+        self.TipoEmissao = TipoEmissao
+        self.validate_tpEmissaoGuia(self.TipoEmissao)
+        self.TipoEmissao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, PedidoConsultaGuia)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if PedidoConsultaGuia.subclass:
+            return PedidoConsultaGuia.subclass(*args_, **kwargs_)
+        else:
+            return PedidoConsultaGuia(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpInscricaoMunicipal(self, value):
+        result = True
+        # Validate type tpInscricaoMunicipal, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpInscricaoMunicipal_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
+                result = False
+        return result
+    validate_tpInscricaoMunicipal_patterns_ = [['^([0-9]{1,12})$']]
+    def validate_tpIncidencia(self, value):
+        result = True
+        # Validate type tpIncidencia, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpIncidencia_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpIncidencia_patterns_, ))
+                result = False
+        return result
+    validate_tpIncidencia_patterns_ = [['^(^((19|20)\\d\\d)-(0?[1-9]|1[012])$)$']]
+    def validate_tpConsultaSituacaoGuias(self, value):
+        result = True
+        # Validate type tpConsultaSituacaoGuias, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [1, 2, 3, 4]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpConsultaSituacaoGuias' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def validate_tpEmissaoGuia(self, value):
+        result = True
+        # Validate type tpEmissaoGuia, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [1, 2, 3, 4, 5, 6, 7, 8]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEmissaoGuia' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.CPFCNPJRemetente is not None or
+            self.InscricaoPrestador is not None or
+            self.Incidencia is not None or
+            self.Situacao is not None or
+            self.TipoEmissao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoConsultaGuia')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'PedidoConsultaGuia':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoConsultaGuia')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoConsultaGuia', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoConsultaGuia'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaGuia', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.CPFCNPJRemetente is not None:
+            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
+            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
+        if self.InscricaoPrestador is not None:
+            namespaceprefix_ = self.InscricaoPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.InscricaoPrestador_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sInscricaoPrestador>%s</%sInscricaoPrestador>%s' % (namespaceprefix_ , self.gds_format_integer(self.InscricaoPrestador, input_name='InscricaoPrestador'), namespaceprefix_ , eol_))
+        if self.Incidencia is not None:
+            namespaceprefix_ = self.Incidencia_nsprefix_ + ':' if (UseCapturedNS_ and self.Incidencia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sIncidencia>%s</%sIncidencia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Incidencia), input_name='Incidencia')), namespaceprefix_ , eol_))
+        if self.Situacao is not None:
+            namespaceprefix_ = self.Situacao_nsprefix_ + ':' if (UseCapturedNS_ and self.Situacao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sSituacao>%s</%sSituacao>%s' % (namespaceprefix_ , self.gds_format_integer(self.Situacao, input_name='Situacao'), namespaceprefix_ , eol_))
+        if self.TipoEmissao is not None:
+            namespaceprefix_ = self.TipoEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.TipoEmissao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sTipoEmissao>%s</%sTipoEmissao>%s' % (namespaceprefix_ , self.gds_format_integer(self.TipoEmissao, input_name='TipoEmissao'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'CPFCNPJRemetente':
+            obj_ = tpCPFCNPJ.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.CPFCNPJRemetente = obj_
+            obj_.original_tagname_ = 'CPFCNPJRemetente'
+        elif nodeName_ == 'InscricaoPrestador' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'InscricaoPrestador')
+            ival_ = self.gds_validate_integer(ival_, node, 'InscricaoPrestador')
+            self.InscricaoPrestador = ival_
+            self.InscricaoPrestador_nsprefix_ = child_.prefix
+            # validate type tpInscricaoMunicipal
+            self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        elif nodeName_ == 'Incidencia':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Incidencia')
+            value_ = self.gds_validate_string(value_, node, 'Incidencia')
+            self.Incidencia = value_
+            self.Incidencia_nsprefix_ = child_.prefix
+            # validate type tpIncidencia
+            self.validate_tpIncidencia(self.Incidencia)
+        elif nodeName_ == 'Situacao' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Situacao')
+            ival_ = self.gds_validate_integer(ival_, node, 'Situacao')
+            self.Situacao = ival_
+            self.Situacao_nsprefix_ = child_.prefix
+            # validate type tpConsultaSituacaoGuias
+            self.validate_tpConsultaSituacaoGuias(self.Situacao)
+        elif nodeName_ == 'TipoEmissao' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'TipoEmissao')
+            ival_ = self.gds_validate_integer(ival_, node, 'TipoEmissao')
+            self.TipoEmissao = ival_
+            self.TipoEmissao_nsprefix_ = child_.prefix
+            # validate type tpEmissaoGuia
+            self.validate_tpEmissaoGuia(self.TipoEmissao)
+# end class PedidoConsultaGuia
+
+
+class RetornoConsultaGuia(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
+        MemberSpec_('Guia', 'tpGuia', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'Guia', 'type': 'tpGuia'}, None),
+        MemberSpec_('Erro', 'tpEventoAsync', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'Erro', 'type': 'tpEventoAsync'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Cabecalho=None, Guia=None, Erro=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1243,59 +1503,62 @@ class PedidoConsultaNFe(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Cabecalho = Cabecalho
         self.Cabecalho_nsprefix_ = None
-        if Detalhe is None:
-            self.Detalhe = []
+        if Guia is None:
+            self.Guia = []
         else:
-            self.Detalhe = Detalhe
-        self.Detalhe_nsprefix_ = None
-        self.Signature = Signature
-        self.Signature_nsprefix_ = None
+            self.Guia = Guia
+        self.Guia_nsprefix_ = None
+        if Erro is None:
+            self.Erro = []
+        else:
+            self.Erro = Erro
+        self.Erro_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoConsultaNFe)
+                CurrentSubclassModule_, RetornoConsultaGuia)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoConsultaNFe.subclass:
-            return PedidoConsultaNFe.subclass(*args_, **kwargs_)
+        if RetornoConsultaGuia.subclass:
+            return RetornoConsultaGuia.subclass(*args_, **kwargs_)
         else:
-            return PedidoConsultaNFe(*args_, **kwargs_)
+            return RetornoConsultaGuia(*args_, **kwargs_)
     factory = staticmethod(factory)
     def has__content(self):
         if (
             self.Cabecalho is not None or
-            self.Detalhe or
-            self.Signature is not None
+            self.Guia or
+            self.Erro
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaNFe', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoConsultaNFe')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RetornoConsultaGuia')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoConsultaNFe':
+        if self.original_tagname_ is not None and name_ == 'RetornoConsultaGuia':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoConsultaNFe')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RetornoConsultaGuia')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoConsultaNFe', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RetornoConsultaGuia', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoConsultaNFe'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RetornoConsultaGuia'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaNFe', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaGuia', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
@@ -1303,12 +1566,12 @@ class PedidoConsultaNFe(GeneratedsSuper):
         if self.Cabecalho is not None:
             namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
             self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
-        for Detalhe_ in self.Detalhe:
-            namespaceprefix_ = self.Detalhe_nsprefix_ + ':' if (UseCapturedNS_ and self.Detalhe_nsprefix_) else ''
-            Detalhe_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Detalhe', pretty_print=pretty_print)
-        if self.Signature is not None:
-            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
-            self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+        for Guia_ in self.Guia:
+            namespaceprefix_ = self.Guia_nsprefix_ + ':' if (UseCapturedNS_ and self.Guia_nsprefix_) else ''
+            Guia_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Guia', pretty_print=pretty_print)
+        for Erro_ in self.Erro:
+            namespaceprefix_ = self.Erro_nsprefix_ + ':' if (UseCapturedNS_ and self.Erro_nsprefix_) else ''
+            Erro_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Erro', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -1328,17 +1591,611 @@ class PedidoConsultaNFe(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.Cabecalho = obj_
             obj_.original_tagname_ = 'Cabecalho'
-        elif nodeName_ == 'Detalhe':
-            obj_ = DetalheType.factory(parent_object_=self)
+        elif nodeName_ == 'Guia':
+            obj_ = tpGuia.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Detalhe.append(obj_)
-            obj_.original_tagname_ = 'Detalhe'
-        elif nodeName_ == 'Signature':
-            obj_ = SignatureType.factory(parent_object_=self)
+            self.Guia.append(obj_)
+            obj_.original_tagname_ = 'Guia'
+        elif nodeName_ == 'Erro':
+            obj_ = tpEventoAsync.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Signature = obj_
-            obj_.original_tagname_ = 'Signature'
-# end class PedidoConsultaNFe
+            self.Erro.append(obj_)
+            obj_.original_tagname_ = 'Erro'
+# end class RetornoConsultaGuia
+
+
+class tpGuias(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Guia', 'tpGuia', 1, 0, {'maxOccurs': 'unbounded', 'minOccurs': '1', 'name': 'Guia', 'type': 'tpGuia'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Guia=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        if Guia is None:
+            self.Guia = []
+        else:
+            self.Guia = Guia
+        self.Guia_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpGuias)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpGuias.subclass:
+            return tpGuias.subclass(*args_, **kwargs_)
+        else:
+            return tpGuias(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def has__content(self):
+        if (
+            self.Guia
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpGuias', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpGuias')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpGuias':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpGuias')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpGuias', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpGuias'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpGuias', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for Guia_ in self.Guia:
+            namespaceprefix_ = self.Guia_nsprefix_ + ':' if (UseCapturedNS_ and self.Guia_nsprefix_) else ''
+            Guia_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Guia', pretty_print=pretty_print)
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Guia':
+            obj_ = tpGuia.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.Guia.append(obj_)
+            obj_.original_tagname_ = 'Guia'
+# end class tpGuias
+
+
+class tpGuia(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('Incidencia', ['tpIncidencia', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Incidencia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorTotal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIss', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIss', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalPagamento', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalPagamento', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('Status', 'tpStatusGuia', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Status', 'type': 'tpStatusGuia'}, None),
+        MemberSpec_('Situacao', ['tpConsultaSituacaoGuias', 'xsd:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Situacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('Referencia', ['tpEmissaoGuia', 'xsd:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Referencia', 'type': 'xsd:int'}, None),
+        MemberSpec_('DataEmissao', 'xsd:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissao', 'type': 'xsd:date'}, None),
+        MemberSpec_('DataVencimento', 'xsd:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataVencimento', 'type': 'xsd:date'}, None),
+        MemberSpec_('DataPagamento', 'xsd:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataPagamento', 'type': 'xsd:date'}, None),
+        MemberSpec_('DataQuitacao', 'xsd:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacao', 'type': 'xsd:date'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:date'}, None),
+        MemberSpec_('LinhaDigitavel', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'LinhaDigitavel', 'type': 'xsd:string'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, InscricaoPrestador=None, NumeroGuia=None, Incidencia=None, ValorTotal=None, ValorIss=None, ValorTotalPagamento=None, Status=None, Situacao=None, Referencia=None, DataEmissao=None, DataVencimento=None, DataPagamento=None, DataQuitacao=None, DataCancelamento=None, LinhaDigitavel=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.InscricaoPrestador = InscricaoPrestador
+        self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        self.InscricaoPrestador_nsprefix_ = None
+        self.NumeroGuia = NumeroGuia
+        self.validate_tpNumero(self.NumeroGuia)
+        self.NumeroGuia_nsprefix_ = None
+        self.Incidencia = Incidencia
+        self.validate_tpIncidencia(self.Incidencia)
+        self.Incidencia_nsprefix_ = None
+        self.ValorTotal = ValorTotal
+        self.validate_tpValor(self.ValorTotal)
+        self.ValorTotal_nsprefix_ = None
+        self.ValorIss = ValorIss
+        self.validate_tpValor(self.ValorIss)
+        self.ValorIss_nsprefix_ = None
+        self.ValorTotalPagamento = ValorTotalPagamento
+        self.validate_tpValor(self.ValorTotalPagamento)
+        self.ValorTotalPagamento_nsprefix_ = None
+        self.Status = Status
+        self.Status_nsprefix_ = None
+        self.Situacao = Situacao
+        self.validate_tpConsultaSituacaoGuias(self.Situacao)
+        self.Situacao_nsprefix_ = None
+        self.Referencia = Referencia
+        self.validate_tpEmissaoGuia(self.Referencia)
+        self.Referencia_nsprefix_ = None
+        if isinstance(DataEmissao, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataEmissao
+        self.DataEmissao = initvalue_
+        self.DataEmissao_nsprefix_ = None
+        if isinstance(DataVencimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataVencimento, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataVencimento
+        self.DataVencimento = initvalue_
+        self.DataVencimento_nsprefix_ = None
+        if isinstance(DataPagamento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataPagamento, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataPagamento
+        self.DataPagamento = initvalue_
+        self.DataPagamento_nsprefix_ = None
+        if isinstance(DataQuitacao, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataQuitacao, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataQuitacao
+        self.DataQuitacao = initvalue_
+        self.DataQuitacao_nsprefix_ = None
+        if isinstance(DataCancelamento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataCancelamento
+        self.DataCancelamento = initvalue_
+        self.DataCancelamento_nsprefix_ = None
+        self.LinhaDigitavel = LinhaDigitavel
+        self.LinhaDigitavel_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpGuia)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpGuia.subclass:
+            return tpGuia.subclass(*args_, **kwargs_)
+        else:
+            return tpGuia(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpInscricaoMunicipal(self, value):
+        result = True
+        # Validate type tpInscricaoMunicipal, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpInscricaoMunicipal_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
+                result = False
+        return result
+    validate_tpInscricaoMunicipal_patterns_ = [['^([0-9]{1,12})$']]
+    def validate_tpNumero(self, value):
+        result = True
+        # Validate type tpNumero, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpNumero_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                result = False
+        return result
+    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
+    def validate_tpIncidencia(self, value):
+        result = True
+        # Validate type tpIncidencia, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpIncidencia_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpIncidencia_patterns_, ))
+                result = False
+        return result
+    validate_tpIncidencia_patterns_ = [['^(^((19|20)\\d\\d)-(0?[1-9]|1[012])$)$']]
+    def validate_tpValor(self, value):
+        result = True
+        # Validate type tpValor, a restriction on xs:decimal.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if value < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
+                result = False
+            if len(str(value)) >= 15:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd totalDigits restriction on tpValor' % {"value": value, "lineno": lineno} )
+                result = False
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpValor_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpValor_patterns_, ))
+                result = False
+        return result
+    validate_tpValor_patterns_ = [['^(0|0\\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\\.[0-9]{0,2})?)$']]
+    def validate_tpConsultaSituacaoGuias(self, value):
+        result = True
+        # Validate type tpConsultaSituacaoGuias, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [1, 2, 3, 4]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpConsultaSituacaoGuias' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def validate_tpEmissaoGuia(self, value):
+        result = True
+        # Validate type tpEmissaoGuia, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [1, 2, 3, 4, 5, 6, 7, 8]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEmissaoGuia' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.InscricaoPrestador is not None or
+            self.NumeroGuia is not None or
+            self.Incidencia is not None or
+            self.ValorTotal is not None or
+            self.ValorIss is not None or
+            self.ValorTotalPagamento is not None or
+            self.Status is not None or
+            self.Situacao is not None or
+            self.Referencia is not None or
+            self.DataEmissao is not None or
+            self.DataVencimento is not None or
+            self.DataPagamento is not None or
+            self.DataQuitacao is not None or
+            self.DataCancelamento is not None or
+            self.LinhaDigitavel is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpGuia')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpGuia':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpGuia')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpGuia', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpGuia'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpGuia', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.InscricaoPrestador is not None:
+            namespaceprefix_ = self.InscricaoPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.InscricaoPrestador_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sInscricaoPrestador>%s</%sInscricaoPrestador>%s' % (namespaceprefix_ , self.gds_format_integer(self.InscricaoPrestador, input_name='InscricaoPrestador'), namespaceprefix_ , eol_))
+        if self.NumeroGuia is not None:
+            namespaceprefix_ = self.NumeroGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroGuia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroGuia>%s</%sNumeroGuia>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroGuia, input_name='NumeroGuia'), namespaceprefix_ , eol_))
+        if self.Incidencia is not None:
+            namespaceprefix_ = self.Incidencia_nsprefix_ + ':' if (UseCapturedNS_ and self.Incidencia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sIncidencia>%s</%sIncidencia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Incidencia), input_name='Incidencia')), namespaceprefix_ , eol_))
+        if self.ValorTotal is not None:
+            namespaceprefix_ = self.ValorTotal_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorTotal_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sValorTotal>%s</%sValorTotal>%s' % (namespaceprefix_ , self.gds_format_decimal(self.ValorTotal, input_name='ValorTotal'), namespaceprefix_ , eol_))
+        if self.ValorIss is not None:
+            namespaceprefix_ = self.ValorIss_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorIss_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sValorIss>%s</%sValorIss>%s' % (namespaceprefix_ , self.gds_format_decimal(self.ValorIss, input_name='ValorIss'), namespaceprefix_ , eol_))
+        if self.ValorTotalPagamento is not None:
+            namespaceprefix_ = self.ValorTotalPagamento_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorTotalPagamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sValorTotalPagamento>%s</%sValorTotalPagamento>%s' % (namespaceprefix_ , self.gds_format_decimal(self.ValorTotalPagamento, input_name='ValorTotalPagamento'), namespaceprefix_ , eol_))
+        if self.Status is not None:
+            namespaceprefix_ = self.Status_nsprefix_ + ':' if (UseCapturedNS_ and self.Status_nsprefix_) else ''
+            self.Status.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Status', pretty_print=pretty_print)
+        if self.Situacao is not None:
+            namespaceprefix_ = self.Situacao_nsprefix_ + ':' if (UseCapturedNS_ and self.Situacao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sSituacao>%s</%sSituacao>%s' % (namespaceprefix_ , self.gds_format_integer(self.Situacao, input_name='Situacao'), namespaceprefix_ , eol_))
+        if self.Referencia is not None:
+            namespaceprefix_ = self.Referencia_nsprefix_ + ':' if (UseCapturedNS_ and self.Referencia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sReferencia>%s</%sReferencia>%s' % (namespaceprefix_ , self.gds_format_integer(self.Referencia, input_name='Referencia'), namespaceprefix_ , eol_))
+        if self.DataEmissao is not None:
+            namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+        if self.DataVencimento is not None:
+            namespaceprefix_ = self.DataVencimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataVencimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataVencimento>%s</%sDataVencimento>%s' % (namespaceprefix_ , self.gds_format_date(self.DataVencimento, input_name='DataVencimento'), namespaceprefix_ , eol_))
+        if self.DataPagamento is not None:
+            namespaceprefix_ = self.DataPagamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataPagamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataPagamento>%s</%sDataPagamento>%s' % (namespaceprefix_ , self.gds_format_date(self.DataPagamento, input_name='DataPagamento'), namespaceprefix_ , eol_))
+        if self.DataQuitacao is not None:
+            namespaceprefix_ = self.DataQuitacao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataQuitacao>%s</%sDataQuitacao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacao, input_name='DataQuitacao'), namespaceprefix_ , eol_))
+        if self.DataCancelamento is not None:
+            namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_date(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+        if self.LinhaDigitavel is not None:
+            namespaceprefix_ = self.LinhaDigitavel_nsprefix_ + ':' if (UseCapturedNS_ and self.LinhaDigitavel_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sLinhaDigitavel>%s</%sLinhaDigitavel>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.LinhaDigitavel), input_name='LinhaDigitavel')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'InscricaoPrestador' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'InscricaoPrestador')
+            ival_ = self.gds_validate_integer(ival_, node, 'InscricaoPrestador')
+            self.InscricaoPrestador = ival_
+            self.InscricaoPrestador_nsprefix_ = child_.prefix
+            # validate type tpInscricaoMunicipal
+            self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        elif nodeName_ == 'NumeroGuia' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'NumeroGuia')
+            ival_ = self.gds_validate_integer(ival_, node, 'NumeroGuia')
+            self.NumeroGuia = ival_
+            self.NumeroGuia_nsprefix_ = child_.prefix
+            # validate type tpNumero
+            self.validate_tpNumero(self.NumeroGuia)
+        elif nodeName_ == 'Incidencia':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Incidencia')
+            value_ = self.gds_validate_string(value_, node, 'Incidencia')
+            self.Incidencia = value_
+            self.Incidencia_nsprefix_ = child_.prefix
+            # validate type tpIncidencia
+            self.validate_tpIncidencia(self.Incidencia)
+        elif nodeName_ == 'ValorTotal' and child_.text:
+            sval_ = child_.text
+            fval_ = self.gds_parse_decimal(sval_, node, 'ValorTotal')
+            fval_ = self.gds_validate_decimal(fval_, node, 'ValorTotal')
+            self.ValorTotal = fval_
+            self.ValorTotal_nsprefix_ = child_.prefix
+            # validate type tpValor
+            self.validate_tpValor(self.ValorTotal)
+        elif nodeName_ == 'ValorIss' and child_.text:
+            sval_ = child_.text
+            fval_ = self.gds_parse_decimal(sval_, node, 'ValorIss')
+            fval_ = self.gds_validate_decimal(fval_, node, 'ValorIss')
+            self.ValorIss = fval_
+            self.ValorIss_nsprefix_ = child_.prefix
+            # validate type tpValor
+            self.validate_tpValor(self.ValorIss)
+        elif nodeName_ == 'ValorTotalPagamento' and child_.text:
+            sval_ = child_.text
+            fval_ = self.gds_parse_decimal(sval_, node, 'ValorTotalPagamento')
+            fval_ = self.gds_validate_decimal(fval_, node, 'ValorTotalPagamento')
+            self.ValorTotalPagamento = fval_
+            self.ValorTotalPagamento_nsprefix_ = child_.prefix
+            # validate type tpValor
+            self.validate_tpValor(self.ValorTotalPagamento)
+        elif nodeName_ == 'Status':
+            obj_ = tpStatusGuia.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.Status = obj_
+            obj_.original_tagname_ = 'Status'
+        elif nodeName_ == 'Situacao' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Situacao')
+            ival_ = self.gds_validate_integer(ival_, node, 'Situacao')
+            self.Situacao = ival_
+            self.Situacao_nsprefix_ = child_.prefix
+            # validate type tpConsultaSituacaoGuias
+            self.validate_tpConsultaSituacaoGuias(self.Situacao)
+        elif nodeName_ == 'Referencia' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Referencia')
+            ival_ = self.gds_validate_integer(ival_, node, 'Referencia')
+            self.Referencia = ival_
+            self.Referencia_nsprefix_ = child_.prefix
+            # validate type tpEmissaoGuia
+            self.validate_tpEmissaoGuia(self.Referencia)
+        elif nodeName_ == 'DataEmissao':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataEmissao = dval_
+            self.DataEmissao_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataVencimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataVencimento = dval_
+            self.DataVencimento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataPagamento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataPagamento = dval_
+            self.DataPagamento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataQuitacao':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataQuitacao = dval_
+            self.DataQuitacao_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataCancelamento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataCancelamento = dval_
+            self.DataCancelamento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'LinhaDigitavel':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'LinhaDigitavel')
+            value_ = self.gds_validate_string(value_, node, 'LinhaDigitavel')
+            self.LinhaDigitavel = value_
+            self.LinhaDigitavel_nsprefix_ = child_.prefix
+# end class tpGuia
+
+
+class tpStatusGuia(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('nome', 'xsd:string', 0, 1, {'use': 'optional', 'name': 'nome'}),
+        MemberSpec_('valueOf_', ['tpStatusGuiaEnum', 'xsd:int'], 0),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, nome=None, valueOf_=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.nome = _cast(None, nome)
+        self.nome_nsprefix_ = None
+        self.valueOf_ = valueOf_
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpStatusGuia)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpStatusGuia.subclass:
+            return tpStatusGuia.subclass(*args_, **kwargs_)
+        else:
+            return tpStatusGuia(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpStatusGuiaEnum(self, value):
+        result = True
+        # Validate type tpStatusGuiaEnum, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [0, 1, 2, 3, 4, 5, 6, 7]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpStatusGuiaEnum' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            (1 if type(self.valueOf_) in [int,float] else self.valueOf_)
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpStatusGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpStatusGuia')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpStatusGuia':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpStatusGuia')
+        outfile.write('>')
+        self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_, pretty_print=pretty_print)
+        outfile.write(self.convert_unicode(self.valueOf_))
+        outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpStatusGuia'):
+        if self.nome is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            outfile.write(' nome=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.nome), input_name='nome')), ))
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpStatusGuia', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        self.valueOf_ = get_all_text_(node)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('nome', node)
+        if value is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            self.nome = value
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        pass
+# end class tpStatusGuia
 
 
 class tpEvento(GeneratedsSuper):
@@ -1360,8 +2217,8 @@ class tpEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xs:short'}, None),
-        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xs:string'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 3),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 3),
     ]
@@ -1398,10 +2255,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoEvento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
@@ -1412,10 +2265,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1528,8 +2377,8 @@ class tpCPFCNPJ(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, 4),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, 4),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, 4),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, 4),
     ]
     subclass = None
     superclass = None
@@ -1560,10 +2409,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1574,10 +2419,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1669,10 +2510,10 @@ class tpCPFCNPJNIF(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -1709,10 +2550,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1723,10 +2560,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1737,10 +2570,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1754,12 +2583,8 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2002,10 +2827,10 @@ class tpChaveNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xs:long'}, None),
-        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xsd:long'}, None),
+        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2042,10 +2867,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2056,10 +2877,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2070,10 +2887,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoVerificacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 8:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoVerificacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2087,10 +2900,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -2220,9 +3029,9 @@ class tpChaveRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xs:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xsd:long'}, None),
     ]
     subclass = None
     superclass = None
@@ -2256,10 +3065,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2270,10 +3075,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpSerieRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 5:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpSerieRPS' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2287,10 +3088,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2423,10 +3220,10 @@ class tpEnderecoExterior(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xs:string'}, None),
-        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xs:string'}, None),
-        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xs:string'}, None),
-        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xsd:string'}, None),
+        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xsd:string'}, None),
+        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2463,10 +3260,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -2477,10 +3270,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEndPostal, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 11:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoEndPostal' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2494,10 +3283,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpNomeCidade, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNomeCidade' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2511,10 +3296,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpEstadoProvinciaRegiao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEstadoProvinciaRegiao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2637,8 +3418,8 @@ class tpEnderecoNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xs:int'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xsd:int'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -2669,10 +3450,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2683,10 +3460,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -2780,14 +3553,14 @@ class tpEndereco(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xs:string'}, None),
-        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xs:int'}, None),
-        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xs:string'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xsd:int'}, None),
+        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xsd:int'}, None),
         MemberSpec_('EnderecoExterior', 'tpEnderecoExterior', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoExterior', 'type': 'tpEnderecoExterior'}, None),
     ]
     subclass = None
@@ -2839,10 +3612,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpTipoLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 3:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTipoLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2856,10 +3625,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2873,10 +3638,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2890,10 +3651,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2907,10 +3664,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2924,10 +3677,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2938,10 +3687,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpUF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpUF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2955,10 +3700,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3141,10 +3882,10 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     member_data_items_ = [
         MemberSpec_('endNac', 'tpEnderecoNacional', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endNac', 'type': 'tpEnderecoNacional'}, 5),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 5),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3185,10 +3926,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3202,10 +3939,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3219,10 +3952,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3236,10 +3965,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3380,12 +4105,12 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, 6),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, 6),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 6),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3427,10 +4152,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3441,10 +4162,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3458,10 +4175,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3475,10 +4188,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3492,10 +4201,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3659,14 +4364,14 @@ class tpInformacoesLote(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('DataEnvioLote', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xs:long'}, None),
-        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('DataEnvioLote', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xsd:string'}, None),
+        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xsd:long'}, None),
+        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -3684,11 +4389,7 @@ class tpInformacoesLote(GeneratedsSuper):
         self.InscricaoPrestador_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        if isinstance(DataEnvioLote, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEnvioLote, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEnvioLote
-        self.DataEnvioLote = initvalue_
+        self.DataEnvioLote = DataEnvioLote
         self.DataEnvioLote_nsprefix_ = None
         self.QtdNotasProcessadas = QtdNotasProcessadas
         self.validate_tpQuantidade(self.QtdNotasProcessadas)
@@ -3717,10 +4418,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -3731,10 +4428,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -3745,10 +4438,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpQuantidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
@@ -3759,10 +4448,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpTempoProcessamento, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpTempoProcessamento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpTempoProcessamento_patterns_, ))
@@ -3773,10 +4458,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -3849,7 +4530,7 @@ class tpInformacoesLote(GeneratedsSuper):
         if self.DataEnvioLote is not None:
             namespaceprefix_ = self.DataEnvioLote_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEnvioLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEnvioLote, input_name='DataEnvioLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEnvioLote), input_name='DataEnvioLote')), namespaceprefix_ , eol_))
         if self.QtdNotasProcessadas is not None:
             namespaceprefix_ = self.QtdNotasProcessadas_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdNotasProcessadas_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -3902,9 +4583,10 @@ class tpInformacoesLote(GeneratedsSuper):
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
         elif nodeName_ == 'DataEnvioLote':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEnvioLote = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEnvioLote')
+            value_ = self.gds_validate_string(value_, node, 'DataEnvioLote')
+            self.DataEnvioLote = value_
             self.DataEnvioLote_nsprefix_ = child_.prefix
         elif nodeName_ == 'QtdNotasProcessadas' and child_.text:
             sval_ = child_.text
@@ -3959,13 +4641,13 @@ class tpInformacoesPessoa(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'end', 'type': 'tpEnderecoIBSCBS'}, None),
-        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xs:string'}, None),
+        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4010,10 +4692,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -4024,10 +4702,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -4038,10 +4712,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4055,12 +4725,8 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4070,10 +4736,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4087,10 +4749,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4246,7 +4904,7 @@ class tpGRefNFSe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xs:string'}, None),
+        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4276,10 +4934,6 @@ class tpGRefNFSe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -4464,9 +5118,9 @@ class tpImovelObra(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xs:string'}, None),
-        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xs:string'}, 7),
-        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xs:string'}, 7),
+        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xsd:string'}, None),
+        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xsd:string'}, 7),
+        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xsd:string'}, 7),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, 7),
     ]
     subclass = None
@@ -4503,10 +5157,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpInscImobFisc, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpInscImobFisc' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4520,10 +5170,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCCIB, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCCIB_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCCIB_patterns_, ))
@@ -4534,10 +5180,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCObra, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCObra' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4708,11 +5350,11 @@ class tpDocumento(GeneratedsSuper):
         MemberSpec_('docFiscalOutro', 'tpDocFiscalOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docFiscalOutro', 'type': 'tpDocFiscalOutro'}, 8),
         MemberSpec_('docOutro', 'tpDocOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docOutro', 'type': 'tpDocOutro'}, 8),
         MemberSpec_('fornec', 'tpFornecedor', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'fornec', 'type': 'tpFornecedor'}, None),
-        MemberSpec_('dtEmiDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('dtCompDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xs:int'}, None),
-        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xs:string'}, None),
-        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('dtEmiDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtCompDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xsd:string'}, None),
+        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -4730,17 +5372,9 @@ class tpDocumento(GeneratedsSuper):
         self.docOutro_nsprefix_ = None
         self.fornec = fornec
         self.fornec_nsprefix_ = None
-        if isinstance(dtEmiDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtEmiDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtEmiDoc
-        self.dtEmiDoc = initvalue_
+        self.dtEmiDoc = dtEmiDoc
         self.dtEmiDoc_nsprefix_ = None
-        if isinstance(dtCompDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtCompDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtCompDoc
-        self.dtCompDoc = initvalue_
+        self.dtCompDoc = dtCompDoc
         self.dtCompDoc_nsprefix_ = None
         self.tpReeRepRes = tpReeRepRes
         self.validate_tpReeRepRes(self.tpReeRepRes)
@@ -4766,12 +5400,8 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpReeRepRes, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 99]
+            enumerations = ['1', '2', '3', '4', '99']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4781,10 +5411,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpXTpReeRepRes, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 150:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4798,10 +5424,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -4876,11 +5498,11 @@ class tpDocumento(GeneratedsSuper):
         if self.dtEmiDoc is not None:
             namespaceprefix_ = self.dtEmiDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtEmiDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtEmiDoc, input_name='dtEmiDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtEmiDoc), input_name='dtEmiDoc')), namespaceprefix_ , eol_))
         if self.dtCompDoc is not None:
             namespaceprefix_ = self.dtCompDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtCompDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtCompDoc, input_name='dtCompDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtCompDoc), input_name='dtCompDoc')), namespaceprefix_ , eol_))
         if self.tpReeRepRes is not None:
             namespaceprefix_ = self.tpReeRepRes_nsprefix_ + ':' if (UseCapturedNS_ and self.tpReeRepRes_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -4928,14 +5550,16 @@ class tpDocumento(GeneratedsSuper):
             self.fornec = obj_
             obj_.original_tagname_ = 'fornec'
         elif nodeName_ == 'dtEmiDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtEmiDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtEmiDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtEmiDoc')
+            self.dtEmiDoc = value_
             self.dtEmiDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtCompDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtCompDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtCompDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtCompDoc')
+            self.dtCompDoc = value_
             self.dtCompDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'tpReeRepRes' and child_.text:
             sval_ = child_.text
@@ -4972,9 +5596,9 @@ class tpDFeNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xs:int'}, None),
-        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xs:string'}, None),
-        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xs:string'}, None),
+        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5008,12 +5632,8 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpTipoChaveDFE, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 9]
+            enumerations = ['1', '2', '3', '9']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpTipoChaveDFE' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5023,10 +5643,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpXTipoChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTipoChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5040,10 +5656,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5182,9 +5794,9 @@ class tpDocFiscalOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xs:int'}, None),
-        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xs:string'}, None),
-        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xs:string'}, None),
+        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xsd:int'}, None),
+        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5218,10 +5830,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -5232,10 +5840,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5359,8 +5963,8 @@ class tpDocOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xs:string'}, None),
-        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xs:string'}, None),
+        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5391,10 +5995,6 @@ class tpDocOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5493,11 +6093,11 @@ class tpFornecedor(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5537,10 +6137,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -5551,10 +6147,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -5565,10 +6157,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5582,12 +6170,8 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5597,10 +6181,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5753,9 +6333,9 @@ class tpAtividadeEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xs:string'}, None),
-        MemberSpec_('dtIniEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xs:date'}, None),
-        MemberSpec_('dtFimEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xs:date'}, None),
+        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtIniEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtFimEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, None),
     ]
     subclass = None
@@ -5769,17 +6349,9 @@ class tpAtividadeEvento(GeneratedsSuper):
         self.xNomeEvt = xNomeEvt
         self.validate_tpXNomeEvt(self.xNomeEvt)
         self.xNomeEvt_nsprefix_ = None
-        if isinstance(dtIniEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtIniEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtIniEvt
-        self.dtIniEvt = initvalue_
+        self.dtIniEvt = dtIniEvt
         self.dtIniEvt_nsprefix_ = None
-        if isinstance(dtFimEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtFimEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtFimEvt
-        self.dtFimEvt = initvalue_
+        self.dtFimEvt = dtFimEvt
         self.dtFimEvt_nsprefix_ = None
         self.end = end
         self.end_nsprefix_ = None
@@ -5798,10 +6370,6 @@ class tpAtividadeEvento(GeneratedsSuper):
         result = True
         # Validate type tpXNomeEvt, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXNomeEvt' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5858,11 +6426,11 @@ class tpAtividadeEvento(GeneratedsSuper):
         if self.dtIniEvt is not None:
             namespaceprefix_ = self.dtIniEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtIniEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtIniEvt, input_name='dtIniEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtIniEvt), input_name='dtIniEvt')), namespaceprefix_ , eol_))
         if self.dtFimEvt is not None:
             namespaceprefix_ = self.dtFimEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFimEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFimEvt, input_name='dtFimEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtFimEvt), input_name='dtFimEvt')), namespaceprefix_ , eol_))
         if self.end is not None:
             namespaceprefix_ = self.end_nsprefix_ + ':' if (UseCapturedNS_ and self.end_nsprefix_) else ''
             self.end.export(outfile, level, namespaceprefix_, namespacedef_='', name_='end', pretty_print=pretty_print)
@@ -5889,14 +6457,16 @@ class tpAtividadeEvento(GeneratedsSuper):
             # validate type tpXNomeEvt
             self.validate_tpXNomeEvt(self.xNomeEvt)
         elif nodeName_ == 'dtIniEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtIniEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtIniEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtIniEvt')
+            self.dtIniEvt = value_
             self.dtIniEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtFimEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtFimEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtFimEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtFimEvt')
+            self.dtFimEvt = value_
             self.dtFimEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'end':
             obj_ = tpEnderecoSimplesIBSCBS.factory(parent_object_=self)
@@ -5978,13 +6548,13 @@ class tpIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xs:int'}, None),
-        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xs:int'}, None),
-        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xs:string'}, None),
-        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xs:int'}, None),
+        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xsd:int'}, None),
+        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xsd:int'}, None),
+        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xsd:int'}, None),
         MemberSpec_('gRefNFSe', 'tpGRefNFSe', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gRefNFSe', 'type': 'tpGRefNFSe'}, None),
-        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xs:int'}, None),
-        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xs:int'}, None),
+        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xsd:int'}, None),
+        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xsd:int'}, None),
         MemberSpec_('dest', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'dest', 'type': 'tpInformacoesPessoa'}, None),
         MemberSpec_('valores', 'tpValores', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'valores', 'type': 'tpValores'}, None),
         MemberSpec_('imovelobra', 'tpImovelObra', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'imovelobra', 'type': 'tpImovelObra'}, None),
@@ -6038,12 +6608,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpFinNFSe, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0]
+            enumerations = ['0']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpFinNFSe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6053,12 +6619,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6073,10 +6635,6 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCIndOp, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCIndOp_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCIndOp_patterns_, ))
@@ -6087,12 +6645,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpOper, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 5]
+            enumerations = ['1', '2', '3', '4', '5']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpOper' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6102,12 +6656,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpEnteGov, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4]
+            enumerations = ['1', '2', '3', '4']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEnteGov' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6117,12 +6667,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpIndDest, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpIndDest' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6314,7 +6860,7 @@ class tpGIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xsd:string'}, None),
         MemberSpec_('gTribRegular', 'tpGTribRegular', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gTribRegular', 'type': 'tpGTribRegular'}, None),
     ]
     subclass = None
@@ -6345,10 +6891,6 @@ class tpGIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6452,7 +6994,7 @@ class tpGTribRegular(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -6480,10 +7022,6 @@ class tpGTribRegular(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6711,45 +7249,45 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Adquirente', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Adquirente', 'type': 'tpInformacoesPessoa'}, None),
-        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xs:decimal'}, None),
+        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -6893,10 +7431,6 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -7953,67 +8487,67 @@ class tpNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, None),
-        MemberSpec_('DataEmissaoNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('DataEmissaoNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissaoRPS', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xs:date'}, None),
-        MemberSpec_('DataFatoGeradorNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xs:dateTime'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissaoRPS', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataFatoGeradorNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJPrestador', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJPrestador', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xs:string'}, None),
+        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoPrestador', 'tpEndereco', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'EnderecoPrestador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xs:string'}, None),
-        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('DataCancelamento', 'xs:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xs:long'}, None),
-        MemberSpec_('DataQuitacaoGuia', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xs:date'}, None),
-        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataQuitacaoGuia', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
         MemberSpec_('RetornoComplementarIBSCBS', 'tpRetornoComplementarIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RetornoComplementarIBSCBS', 'type': 'tpRetornoComplementarIBSCBS'}, None),
     ]
@@ -8030,11 +8564,7 @@ class tpNFe(GeneratedsSuper):
         self.Assinatura_nsprefix_ = None
         self.ChaveNFe = ChaveNFe
         self.ChaveNFe_nsprefix_ = None
-        if isinstance(DataEmissaoNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEmissaoNFe
-        self.DataEmissaoNFe = initvalue_
+        self.DataEmissaoNFe = DataEmissaoNFe
         self.DataEmissaoNFe_nsprefix_ = None
         self.NumeroLote = NumeroLote
         self.validate_tpNumero(self.NumeroLote)
@@ -8044,17 +8574,9 @@ class tpNFe(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissaoRPS, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoRPS, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissaoRPS
-        self.DataEmissaoRPS = initvalue_
+        self.DataEmissaoRPS = DataEmissaoRPS
         self.DataEmissaoRPS_nsprefix_ = None
-        if isinstance(DataFatoGeradorNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataFatoGeradorNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataFatoGeradorNFe
-        self.DataFatoGeradorNFe = initvalue_
+        self.DataFatoGeradorNFe = DataFatoGeradorNFe
         self.DataFatoGeradorNFe_nsprefix_ = None
         self.CPFCNPJPrestador = CPFCNPJPrestador
         self.CPFCNPJPrestador_nsprefix_ = None
@@ -8069,11 +8591,7 @@ class tpNFe(GeneratedsSuper):
         self.StatusNFe = StatusNFe
         self.validate_tpStatusNFe(self.StatusNFe)
         self.StatusNFe_nsprefix_ = None
-        if isinstance(DataCancelamento, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataCancelamento
-        self.DataCancelamento = initvalue_
+        self.DataCancelamento = DataCancelamento
         self.DataCancelamento_nsprefix_ = None
         self.TributacaoNFe = TributacaoNFe
         self.validate_tpTributacaoNFe(self.TributacaoNFe)
@@ -8084,11 +8602,7 @@ class tpNFe(GeneratedsSuper):
         self.NumeroGuia = NumeroGuia
         self.validate_tpNumero(self.NumeroGuia)
         self.NumeroGuia_nsprefix_ = None
-        if isinstance(DataQuitacaoGuia, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataQuitacaoGuia, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataQuitacaoGuia
-        self.DataQuitacaoGuia = initvalue_
+        self.DataQuitacaoGuia = DataQuitacaoGuia
         self.DataQuitacaoGuia_nsprefix_ = None
         self.ValorServicos = ValorServicos
         self.validate_tpValor(self.ValorServicos)
@@ -8238,10 +8752,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -8252,10 +8762,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -8267,10 +8773,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8284,10 +8786,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8301,10 +8799,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -8316,10 +8810,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8333,10 +8823,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpOpcaoSimples, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['0', '1', '2', '3', '4', '6']
             if value not in enumerations:
@@ -8348,10 +8834,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -8370,10 +8852,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -8384,10 +8862,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -8401,10 +8875,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -8415,10 +8885,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -8429,10 +8895,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8446,10 +8908,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -8463,10 +8921,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8480,10 +8934,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -8494,12 +8944,8 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8514,10 +8960,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -8528,10 +8970,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -8542,10 +8980,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -8661,7 +9095,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoNFe is not None:
             namespaceprefix_ = self.DataEmissaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEmissaoNFe, input_name='DataEmissaoNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoNFe), input_name='DataEmissaoNFe')), namespaceprefix_ , eol_))
         if self.NumeroLote is not None:
             namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8676,11 +9110,11 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoRPS is not None:
             namespaceprefix_ = self.DataEmissaoRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissaoRPS, input_name='DataEmissaoRPS'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoRPS), input_name='DataEmissaoRPS')), namespaceprefix_ , eol_))
         if self.DataFatoGeradorNFe is not None:
             namespaceprefix_ = self.DataFatoGeradorNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataFatoGeradorNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataFatoGeradorNFe, input_name='DataFatoGeradorNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataFatoGeradorNFe), input_name='DataFatoGeradorNFe')), namespaceprefix_ , eol_))
         if self.CPFCNPJPrestador is not None:
             namespaceprefix_ = self.CPFCNPJPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJPrestador_nsprefix_) else ''
             self.CPFCNPJPrestador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJPrestador', pretty_print=pretty_print)
@@ -8702,7 +9136,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataCancelamento is not None:
             namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataCancelamento), input_name='DataCancelamento')), namespaceprefix_ , eol_))
         if self.TributacaoNFe is not None:
             namespaceprefix_ = self.TributacaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.TributacaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8718,7 +9152,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataQuitacaoGuia is not None:
             namespaceprefix_ = self.DataQuitacaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacaoGuia_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacaoGuia, input_name='DataQuitacaoGuia'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataQuitacaoGuia), input_name='DataQuitacaoGuia')), namespaceprefix_ , eol_))
         if self.ValorServicos is not None:
             namespaceprefix_ = self.ValorServicos_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorServicos_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8766,7 +9200,7 @@ class tpNFe(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -8927,9 +9361,10 @@ class tpNFe(GeneratedsSuper):
             self.ChaveNFe = obj_
             obj_.original_tagname_ = 'ChaveNFe'
         elif nodeName_ == 'DataEmissaoNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEmissaoNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoNFe')
+            self.DataEmissaoNFe = value_
             self.DataEmissaoNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'NumeroLote' and child_.text:
             sval_ = child_.text
@@ -8953,14 +9388,16 @@ class tpNFe(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissaoRPS':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissaoRPS = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoRPS')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoRPS')
+            self.DataEmissaoRPS = value_
             self.DataEmissaoRPS_nsprefix_ = child_.prefix
         elif nodeName_ == 'DataFatoGeradorNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataFatoGeradorNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataFatoGeradorNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataFatoGeradorNFe')
+            self.DataFatoGeradorNFe = value_
             self.DataFatoGeradorNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJPrestador':
             obj_ = tpCPFCNPJ.factory(parent_object_=self)
@@ -8997,9 +9434,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpStatusNFe
             self.validate_tpStatusNFe(self.StatusNFe)
         elif nodeName_ == 'DataCancelamento':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataCancelamento = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataCancelamento')
+            value_ = self.gds_validate_string(value_, node, 'DataCancelamento')
+            self.DataCancelamento = value_
             self.DataCancelamento_nsprefix_ = child_.prefix
         elif nodeName_ == 'TributacaoNFe':
             value_ = child_.text
@@ -9026,9 +9464,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpNumero
             self.validate_tpNumero(self.NumeroGuia)
         elif nodeName_ == 'DataQuitacaoGuia':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataQuitacaoGuia = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataQuitacaoGuia')
+            value_ = self.gds_validate_string(value_, node, 'DataQuitacaoGuia')
+            self.DataQuitacaoGuia = value_
             self.DataQuitacaoGuia_nsprefix_ = child_.prefix
         elif nodeName_ == 'ValorServicos' and child_.text:
             sval_ = child_.text
@@ -9119,10 +9558,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpValor
             self.validate_tpValor(self.ValorCredito)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -9674,52 +10113,52 @@ class tpRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissao', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xs:date'}, None),
-        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissao', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
     ]
     subclass = None
@@ -9738,11 +10177,7 @@ class tpRPS(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissao, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissao
-        self.DataEmissao = initvalue_
+        self.DataEmissao = DataEmissao
         self.DataEmissao_nsprefix_ = None
         self.StatusRPS = StatusRPS
         self.validate_tpStatusNFe(self.StatusRPS)
@@ -9887,10 +10322,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -9902,10 +10333,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -9917,10 +10344,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -9934,10 +10357,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -9956,10 +10375,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -9970,10 +10385,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -9987,10 +10398,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -10001,10 +10408,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -10015,10 +10418,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10032,10 +10431,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10049,10 +10444,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10066,10 +10457,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -10083,10 +10470,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10100,10 +10483,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -10114,10 +10493,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -10128,12 +10503,8 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10148,10 +10519,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -10162,10 +10529,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -10176,10 +10539,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -10283,7 +10642,7 @@ class tpRPS(GeneratedsSuper):
         if self.DataEmissao is not None:
             namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissao), input_name='DataEmissao')), namespaceprefix_ , eol_))
         if self.StatusRPS is not None:
             namespaceprefix_ = self.StatusRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.StatusRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -10327,7 +10686,7 @@ class tpRPS(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -10493,9 +10852,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissao':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissao = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissao')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissao')
+            self.DataEmissao = value_
             self.DataEmissao_nsprefix_ = child_.prefix
         elif nodeName_ == 'StatusRPS':
             value_ = child_.text
@@ -10578,10 +10938,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpAliquota
             self.validate_tpAliquota(self.AliquotaServicos)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -10828,7 +11188,7 @@ class tpRPS(GeneratedsSuper):
 class SignatureType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('SignedInfo', 'SignedInfoType', 0, 0, {'name': 'SignedInfo', 'type': 'SignedInfoType'}, None),
         MemberSpec_('SignatureValue', 'SignatureValueType', 0, 0, {'name': 'SignatureValue', 'type': 'SignatureValueType'}, None),
         MemberSpec_('KeyInfo', 'KeyInfoType', 0, 0, {'name': 'KeyInfo', 'type': 'KeyInfoType'}, None),
@@ -10895,7 +11255,7 @@ class SignatureType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -10948,8 +11308,8 @@ class SignatureType(GeneratedsSuper):
 class SignatureValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
-        MemberSpec_('valueOf_', 'xs:base64Binary', 0),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('valueOf_', 'base64Binary', 0),
     ]
     subclass = None
     superclass = None
@@ -11003,7 +11363,7 @@ class SignatureValueType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureValueType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureValueType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -11031,7 +11391,7 @@ class SignatureValueType(GeneratedsSuper):
 class SignedInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('CanonicalizationMethod', 'CanonicalizationMethodType', 0, 0, {'name': 'CanonicalizationMethod', 'type': 'CanonicalizationMethodType'}, None),
         MemberSpec_('SignatureMethod', 'SignatureMethodType', 0, 0, {'name': 'SignatureMethod', 'type': 'SignatureMethodType'}, None),
         MemberSpec_('Reference', 'ReferenceType', 1, 0, {'maxOccurs': 'unbounded', 'name': 'Reference', 'type': 'ReferenceType'}, None),
@@ -11101,7 +11461,7 @@ class SignedInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignedInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignedInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11154,12 +11514,12 @@ class SignedInfoType(GeneratedsSuper):
 class ReferenceType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('URI', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'URI'}),
         MemberSpec_('Type', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'Type'}),
         MemberSpec_('Transforms', 'TransformsType', 0, 0, {'name': 'Transforms', 'type': 'TransformsType'}, None),
         MemberSpec_('DigestMethod', 'DigestMethodType', 0, 0, {'name': 'DigestMethod', 'type': 'DigestMethodType'}, None),
-        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -11234,13 +11594,13 @@ class ReferenceType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='ReferenceType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
         if self.URI is not None and 'URI' not in already_processed:
             already_processed.add('URI')
-            outfile.write(' URI=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.URI), input_name='URI')), ))
+            outfile.write(' URI=%s' % (quote_attrib(self.URI), ))
         if self.Type is not None and 'Type' not in already_processed:
             already_processed.add('Type')
-            outfile.write(' Type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Type), input_name='Type')), ))
+            outfile.write(' Type=%s' % (quote_attrib(self.Type), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='ReferenceType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11403,7 +11763,7 @@ class TransformType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Algorithm', 'xs:anyURI', 0, 0, {'use': 'required', 'name': 'Algorithm'}),
-        MemberSpec_('XPath', 'xs:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xs:string'}, None),
+        MemberSpec_('XPath', 'xsd:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11419,7 +11779,7 @@ class TransformType(GeneratedsSuper):
             self.XPath = []
         else:
             self.XPath = XPath
-        self.XPath_nsprefix_ = None
+        self.XPath_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11464,7 +11824,7 @@ class TransformType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='TransformType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='TransformType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11503,7 +11863,7 @@ class TransformType(GeneratedsSuper):
 class KeyInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('X509Data', 'X509DataType', 0, 0, {'name': 'X509Data', 'type': 'X509DataType'}, None),
     ]
     subclass = None
@@ -11562,7 +11922,7 @@ class KeyInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='KeyInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='KeyInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11687,7 +12047,7 @@ class KeyValueType(GeneratedsSuper):
 class X509DataType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('X509Certificate', 'xs:base64Binary', 0, 0, {'name': 'X509Certificate', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('X509Certificate', 'xsd:string', 0, 0, {'name': 'X509Certificate', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11698,7 +12058,7 @@ class X509DataType(GeneratedsSuper):
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
         self.X509Certificate = X509Certificate
-        self.X509Certificate_nsprefix_ = None
+        self.X509Certificate_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11750,7 +12110,7 @@ class X509DataType(GeneratedsSuper):
         if self.X509Certificate is not None:
             namespaceprefix_ = self.X509Certificate_nsprefix_ + ':' if (UseCapturedNS_ and self.X509Certificate_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_format_base64(self.X509Certificate, input_name='X509Certificate'), namespaceprefix_ , eol_))
+            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.X509Certificate), input_name='X509Certificate')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11766,38 +12126,429 @@ class X509DataType(GeneratedsSuper):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if nodeName_ == 'X509Certificate':
-            sval_ = child_.text
-            if sval_ is not None:
-                try:
-                    bval_ = base64.b64decode(sval_)
-                except (TypeError, ValueError) as exp:
-                    raise_parse_error(child_, 'requires base64 encoded string: %s' % exp)
-                bval_ = self.gds_validate_base64(bval_, node, 'X509Certificate')
-            else:
-                bval_ = None
-            self.X509Certificate = bval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'X509Certificate')
+            value_ = self.gds_validate_string(value_, node, 'X509Certificate')
+            self.X509Certificate = value_
             self.X509Certificate_nsprefix_ = child_.prefix
 # end class X509DataType
 
 
-class CabecalhoType(GeneratedsSuper):
-    """CabecalhoType -- Cabe
+class tpEventoAsync(GeneratedsSuper):
+    """Codigo -- C
+    ó
+    digo do evento.
+    Descricao -- Descri
     ç
-    alho do pedido.
-    Versao -- Informe a Vers
     ã
-    o do Schema XML utilizado.
-    CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
+    o do evento.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
-        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Codigo=None, Descricao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.Codigo = Codigo
+        self.validate_tpCodigoEvento(self.Codigo)
+        self.Codigo_nsprefix_ = None
+        self.Descricao = Descricao
+        self.validate_tpDescricaoEvento(self.Descricao)
+        self.Descricao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpEventoAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpEventoAsync.subclass:
+            return tpEventoAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpEventoAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpCodigoEvento(self, value):
+        result = True
+        # Validate type tpCodigoEvento, a restriction on xs:short.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpCodigoEvento_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
+                result = False
+        return result
+    validate_tpCodigoEvento_patterns_ = [['^([0-9]{3,4})$']]
+    def validate_tpDescricaoEvento(self, value):
+        result = True
+        # Validate type tpDescricaoEvento, a restriction on xs:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if len(value) > 300:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.Codigo is not None or
+            self.Descricao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpEventoAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpEventoAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpEventoAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpEventoAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpEventoAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Codigo is not None:
+            namespaceprefix_ = self.Codigo_nsprefix_ + ':' if (UseCapturedNS_ and self.Codigo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sCodigo>%s</%sCodigo>%s' % (namespaceprefix_ , self.gds_format_integer(self.Codigo, input_name='Codigo'), namespaceprefix_ , eol_))
+        if self.Descricao is not None:
+            namespaceprefix_ = self.Descricao_nsprefix_ + ':' if (UseCapturedNS_ and self.Descricao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDescricao>%s</%sDescricao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Descricao), input_name='Descricao')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Codigo' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Codigo')
+            ival_ = self.gds_validate_integer(ival_, node, 'Codigo')
+            self.Codigo = ival_
+            self.Codigo_nsprefix_ = child_.prefix
+            # validate type tpCodigoEvento
+            self.validate_tpCodigoEvento(self.Codigo)
+        elif nodeName_ == 'Descricao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Descricao')
+            value_ = self.gds_validate_string(value_, node, 'Descricao')
+            self.Descricao = value_
+            self.Descricao_nsprefix_ = child_.prefix
+            # validate type tpDescricaoEvento
+            self.validate_tpDescricaoEvento(self.Descricao)
+# end class tpEventoAsync
+
+
+class tpInformacoesLoteAsync(GeneratedsSuper):
+    """tpInformacoesLoteAsync -- Informa
+    ç
+    õ
+    es do lote processado.
+    NumeroProtocolo -- N
+    ú
+    mero do protocolo do lote.
+    DataRecebimento -- Data/hora de envio do lote.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesLoteAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesLoteAsync.subclass:
+            return tpInformacoesLoteAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesLoteAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesLoteAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesLoteAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesLoteAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesLoteAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesLoteAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesLoteAsync
+
+
+class tpInformacoesGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesGuiaAsync.subclass:
+            return tpInformacoesGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesGuiaAsync
+
+
+class CabecalhoType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
+        MemberSpec_('Sucesso', ['tpSucesso', 'xs:boolean'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Sucesso', 'type': 'xsd:boolean'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Versao=None, Sucesso=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -11805,8 +12556,9 @@ class CabecalhoType(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Versao = _cast(None, Versao)
         self.Versao_nsprefix_ = None
-        self.CPFCNPJRemetente = CPFCNPJRemetente
-        self.CPFCNPJRemetente_nsprefix_ = None
+        self.Sucesso = Sucesso
+        self.validate_tpSucesso(self.Sucesso)
+        self.Sucesso_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11818,20 +12570,22 @@ class CabecalhoType(GeneratedsSuper):
         else:
             return CabecalhoType(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def validate_tpSucesso(self, value):
+        result = True
+        # Validate type tpSucesso, a restriction on xs:boolean.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            pass
+        return result
     def validate_tpVersao(self, value):
         # Validate type tipos:tpVersao, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpVersao_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpVersao_patterns_, ))
     validate_tpVersao_patterns_ = [['^([0-9]{1,3})$']]
     def has__content(self):
         if (
-            self.CPFCNPJRemetente is not None
+            self.Sucesso is not None
         ):
             return True
         else:
@@ -11862,15 +12616,16 @@ class CabecalhoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CabecalhoType'):
         if self.Versao is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            outfile.write(' Versao="%s"' % self.gds_format_integer(self.Versao, input_name='Versao'))
+            outfile.write(' Versao=%s' % (quote_attrib(self.Versao), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.CPFCNPJRemetente is not None:
-            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
-            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
+        if self.Sucesso is not None:
+            namespaceprefix_ = self.Sucesso_nsprefix_ + ':' if (UseCapturedNS_ and self.Sucesso_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sSucesso>%s</%sSucesso>%s' % (namespaceprefix_ , self.gds_format_boolean(self.Sucesso, input_name='Sucesso'), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11886,120 +12641,18 @@ class CabecalhoType(GeneratedsSuper):
         value = find_attr_value_('Versao', node)
         if value is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            self.Versao = self.gds_parse_integer(value, node, 'Versao')
+            self.Versao = value
             self.validate_tpVersao(self.Versao)    # validate type tpVersao
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'CPFCNPJRemetente':
-            obj_ = tpCPFCNPJ.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.CPFCNPJRemetente = obj_
-            obj_.original_tagname_ = 'CPFCNPJRemetente'
+        if nodeName_ == 'Sucesso':
+            sval_ = child_.text
+            ival_ = self.gds_parse_boolean(sval_, node, 'Sucesso')
+            ival_ = self.gds_validate_boolean(ival_, node, 'Sucesso')
+            self.Sucesso = ival_
+            self.Sucesso_nsprefix_ = child_.prefix
+            # validate type tpSucesso
+            self.validate_tpSucesso(self.Sucesso)
 # end class CabecalhoType
-
-
-class DetalheType(GeneratedsSuper):
-    """DetalheType -- Detalhe do pedido. Cada item de detalhe dever
-    á
-    conter a chave de uma NFS-e ou a chave de um RPS.
-    
-    """
-    __hash__ = GeneratedsSuper.__hash__
-    member_data_items_ = [
-        MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 11),
-        MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 11),
-    ]
-    subclass = None
-    superclass = None
-    def __init__(self, ChaveRPS=None, ChaveNFe=None, gds_collector_=None, **kwargs_):
-        self.gds_collector_ = gds_collector_
-        self.gds_elementtree_node_ = None
-        self.original_tagname_ = None
-        self.parent_object_ = kwargs_.get('parent_object_')
-        self.ns_prefix_ = None
-        self.ChaveRPS = ChaveRPS
-        self.ChaveRPS_nsprefix_ = None
-        self.ChaveNFe = ChaveNFe
-        self.ChaveNFe_nsprefix_ = None
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, DetalheType)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if DetalheType.subclass:
-            return DetalheType.subclass(*args_, **kwargs_)
-        else:
-            return DetalheType(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def has__content(self):
-        if (
-            self.ChaveRPS is not None or
-            self.ChaveNFe is not None
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DetalheType', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('DetalheType')
-        if imported_ns_def_ is not None:
-            namespacedef_ = imported_ns_def_
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'DetalheType':
-            name_ = self.original_tagname_
-        if UseCapturedNS_ and self.ns_prefix_:
-            namespaceprefix_ = self.ns_prefix_ + ':'
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='DetalheType')
-        if self.has__content():
-            outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='DetalheType', pretty_print=pretty_print)
-            showIndent(outfile, level, pretty_print)
-            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DetalheType'):
-        pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DetalheType', fromsubclass_=False, pretty_print=True):
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.ChaveRPS is not None:
-            namespaceprefix_ = self.ChaveRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.ChaveRPS_nsprefix_) else ''
-            self.ChaveRPS.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChaveRPS', pretty_print=pretty_print)
-        if self.ChaveNFe is not None:
-            namespaceprefix_ = self.ChaveNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.ChaveNFe_nsprefix_) else ''
-            self.ChaveNFe.export(outfile, level, namespaceprefix_, namespacedef_='', name_='ChaveNFe', pretty_print=pretty_print)
-    def build(self, node, gds_collector_=None):
-        self.gds_collector_ = gds_collector_
-        if SaveElementTreeNode:
-            self.gds_elementtree_node_ = node
-        already_processed = set()
-        self.ns_prefix_ = node.prefix
-        self._buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
-        return self
-    def _buildAttributes(self, node, attrs, already_processed):
-        pass
-    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'ChaveRPS':
-            obj_ = tpChaveRPS.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.ChaveRPS = obj_
-            obj_.original_tagname_ = 'ChaveRPS'
-        elif nodeName_ == 'ChaveNFe':
-            obj_ = tpChaveNFe.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.ChaveNFe = obj_
-            obj_.original_tagname_ = 'ChaveNFe'
-# end class DetalheType
 
 
 class CanonicalizationMethodType(GeneratedsSuper):
@@ -12060,7 +12713,7 @@ class CanonicalizationMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CanonicalizationMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CanonicalizationMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12142,7 +12795,7 @@ class SignatureMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SignatureMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SignatureMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12224,7 +12877,7 @@ class DigestMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DigestMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DigestMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12251,8 +12904,8 @@ class DigestMethodType(GeneratedsSuper):
 class RSAKeyValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xs:base64Binary'}, None),
-        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xsd:base64Binary'}, None),
+        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -12430,8 +13083,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoConsultaNFe'
-        rootClass = PedidoConsultaNFe
+        rootTag = 'PedidoConsultaGuia'
+        rootClass = PedidoConsultaGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12462,8 +13115,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoConsultaNFe'
-        rootClass = PedidoConsultaNFe
+        rootTag = 'PedidoConsultaGuia'
+        rootClass = PedidoConsultaGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12508,8 +13161,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoConsultaNFe'
-        rootClass = PedidoConsultaNFe
+        rootTag = 'PedidoConsultaGuia'
+        rootClass = PedidoConsultaGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12518,7 +13171,7 @@ def parseString(inString, silence=False, print_warnings=True):
         sys.stdout.write('<?xml version="1.0" ?>\n')
         rootObj.export(
             sys.stdout, 0, name_=rootTag,
-            namespacedef_='')
+            namespacedef_='xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"')
     if print_warnings and len(gds_collector.get_messages()) > 0:
         separator = ('-' * 50) + '\n'
         sys.stderr.write(separator)
@@ -12536,8 +13189,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoConsultaNFe'
-        rootClass = PedidoConsultaNFe
+        rootTag = 'PedidoConsultaGuia'
+        rootClass = PedidoConsultaGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12545,8 +13198,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoConsultaNFe import *\n\n')
-        sys.stdout.write('import PedidoConsultaNFe as model_\n\n')
+        sys.stdout.write('#from ConsultaGuia import *\n\n')
+        sys.stdout.write('import ConsultaGuia as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12579,7 +13232,21 @@ RenameMappings_ = {
 # Mapping of namespaces to types defined in them
 # and the file in which each is defined.
 # simpleTypes are marked "ST" and complexTypes "CT".
-NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
+NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [('tpConsultaSituacaoGuias',
+                                          'schemas/nfse/ConsultaGuia_v02.xsd',
+                                          'ST'),
+                                         ('tpStatusGuiaEnum',
+                                          'schemas/nfse/ConsultaGuia_v02.xsd',
+                                          'ST'),
+                                         ('tpGuias',
+                                          'schemas/nfse/ConsultaGuia_v02.xsd',
+                                          'CT'),
+                                         ('tpGuia',
+                                          'schemas/nfse/ConsultaGuia_v02.xsd',
+                                          'CT'),
+                                         ('tpStatusGuia',
+                                          'schemas/nfse/ConsultaGuia_v02.xsd',
+                                          'CT')],
  'http://www.prefeitura.sp.gov.br/nfe/tipos': [('tpAliquota',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
                                                 'ST'),
@@ -12861,6 +13528,30 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                                 'CT'),
                                                ('tpRPS',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
+                                                'CT'),
+                                               ('tpNumeroProtocoloAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpIncidencia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoLote',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEmissaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEventoAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesLoteAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesGuiaAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
                                                 'CT')],
  'http://www.w3.org/2000/09/xmldsig#': [('CryptoBinary',
                                          'schemas/nfse/xmldsig-core-schema_v02.xsd',
@@ -12899,13 +13590,13 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
 __all__ = [
     "CabecalhoType",
     "CanonicalizationMethodType",
-    "DetalheType",
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoConsultaNFe",
+    "PedidoConsultaGuia",
     "RSAKeyValueType",
     "ReferenceType",
+    "RetornoConsultaGuia",
     "SignatureMethodType",
     "SignatureType",
     "SignatureValueType",
@@ -12929,18 +13620,24 @@ __all__ = [
     "tpEnderecoNacional",
     "tpEnderecoSimplesIBSCBS",
     "tpEvento",
+    "tpEventoAsync",
     "tpFornecedor",
     "tpGIBSCBS",
     "tpGRefNFSe",
     "tpGTribRegular",
     "tpGrupoReeRepRes",
+    "tpGuia",
+    "tpGuias",
     "tpIBSCBS",
     "tpImovelObra",
+    "tpInformacoesGuiaAsync",
     "tpInformacoesLote",
+    "tpInformacoesLoteAsync",
     "tpInformacoesPessoa",
     "tpNFe",
     "tpRPS",
     "tpRetornoComplementarIBSCBS",
+    "tpStatusGuia",
     "tpTrib",
     "tpValores"
 ]

--- a/nfselib/paulistana/v03/ConsultaSituacaoGuiaAsync.py
+++ b/nfselib/paulistana/v03/ConsultaSituacaoGuiaAsync.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoCancelamentoLote.py')
+#   ('-o', 'nfselib/paulistana/v03/ConsultaSituacaoGuiaAsync.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   schemas/nfse/ConsultaSituacaoGuiaAsync_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoLote.py" schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/ConsultaSituacaoGuiaAsync.py" schemas/nfse/ConsultaSituacaoGuiaAsync_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1008,6 +1008,17 @@ def _cast(typ, value):
 #
 # Start enum classes
 #
+class tpEmissaoGuia(str, Enum):
+    _1='1' # Guia de NFS-e emitidas
+    _2='2' # Guia de NFS-e recebidas (exceto rejeitadas)
+    _3='3' # Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)
+    _4='4' # Guia de NFS-e recebidas aceitas
+    _5='5' # Guia de NFS-e recebidas sem manifestação do tomador
+    _6='6' # Guia de NFS-e recebidas rejeitadas
+    _7='7' # Guia de NFTS emitidas
+    _8='8' # Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)
+
+
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
     
@@ -1162,6 +1173,42 @@ class tpReferencia(str, Enum):
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
 
 
+class tpSituacaoGuia(str, Enum):
+    """tpSituacaoGuia -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es da emiss
+    ã
+    o de guia ass
+    í
+    ncrona.
+    
+    """
+    SOLICITADA='solicitada' # Emissao solicitada (0).
+    INVALIDADA='invalidada' # Emissao invalidada (1).
+    VERIFICADA='verificada' # Emissao verificada (2).
+    PROCESSADA='processada' # Emissao processada (3).
+
+
+class tpSituacaoLote(str, Enum):
+    """tpSituacaoLote -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es do lote ass
+    í
+    ncrono.
+    
+    """
+    ENVIADO='enviado' # Lote enviado (0).
+    INVALIDADO='invalidado' # Lote invalidado (1).
+    VERIFICADO='verificado' # Lote verificado (2).
+    PROCESSADO='processado' # Lote processado (3).
+
+
 class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
@@ -1211,91 +1258,101 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoCancelamentoLote(GeneratedsSuper):
-    """PedidoCancelamentoLote -- Schema utilizado para PEDIDO de cancelamento de lote.
-    Este Schema XML
-    é
-    utilizado pelos prestadores de servi
-    ç
-    os cancelarem as NFS-e geradas a partir de um lote de RPS.
-    Cabecalho -- Cabe
-    ç
-    alho do pedido de cancelamento de lote.
-    Signature -- Assinatura digital do CNPJ emissor dos RPS.
+class PedidoConsultaSituacaoGuia(GeneratedsSuper):
+    """CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
-        MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
+        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, CPFCNPJRemetente=None, NumeroProtocolo=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
-        self.Cabecalho = Cabecalho
-        self.Cabecalho_nsprefix_ = None
-        self.Signature = Signature
-        self.Signature_nsprefix_ = None
+        self.CPFCNPJRemetente = CPFCNPJRemetente
+        self.CPFCNPJRemetente_nsprefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoCancelamentoLote)
+                CurrentSubclassModule_, PedidoConsultaSituacaoGuia)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoCancelamentoLote.subclass:
-            return PedidoCancelamentoLote.subclass(*args_, **kwargs_)
+        if PedidoConsultaSituacaoGuia.subclass:
+            return PedidoConsultaSituacaoGuia.subclass(*args_, **kwargs_)
         else:
-            return PedidoCancelamentoLote(*args_, **kwargs_)
+            return PedidoConsultaSituacaoGuia(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
     def has__content(self):
         if (
-            self.Cabecalho is not None or
-            self.Signature is not None
+            self.CPFCNPJRemetente is not None or
+            self.NumeroProtocolo is not None
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoCancelamentoLote')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaSituacaoGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoConsultaSituacaoGuia')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoCancelamentoLote':
+        if self.original_tagname_ is not None and name_ == 'PedidoConsultaSituacaoGuia':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoCancelamentoLote')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoConsultaSituacaoGuia')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoCancelamentoLote', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoConsultaSituacaoGuia', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoCancelamentoLote'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoConsultaSituacaoGuia'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaSituacaoGuia', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.Cabecalho is not None:
-            namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
-            self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
-        if self.Signature is not None:
-            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
-            self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+        if self.CPFCNPJRemetente is not None:
+            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
+            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -1310,17 +1367,190 @@ class PedidoCancelamentoLote(GeneratedsSuper):
     def _buildAttributes(self, node, attrs, already_processed):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'Cabecalho':
-            obj_ = CabecalhoType.factory(parent_object_=self)
+        if nodeName_ == 'CPFCNPJRemetente':
+            obj_ = tpCPFCNPJ.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Cabecalho = obj_
-            obj_.original_tagname_ = 'Cabecalho'
-        elif nodeName_ == 'Signature':
-            obj_ = SignatureType.factory(parent_object_=self)
+            self.CPFCNPJRemetente = obj_
+            obj_.original_tagname_ = 'CPFCNPJRemetente'
+        elif nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+# end class PedidoConsultaSituacaoGuia
+
+
+class RetornoConsultaSituacaoGuia(GeneratedsSuper):
+    """NumeroGuia -- N
+    ú
+    mero da guia ap
+    ó
+    s processamento.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Situacao', 'SituacaoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Situacao', 'type': 'SituacaoType'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+        MemberSpec_('DataProcessamento', 'xsd:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataProcessamento', 'type': 'xsd:dateTime'}, None),
+        MemberSpec_('ResultadoOperacao', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ResultadoOperacao', 'type': 'xsd:string'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Situacao=None, NumeroGuia=None, DataRecebimento=None, DataProcessamento=None, ResultadoOperacao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.Situacao = Situacao
+        self.Situacao_nsprefix_ = None
+        self.NumeroGuia = NumeroGuia
+        self.validate_tpNumero(self.NumeroGuia)
+        self.NumeroGuia_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+        if isinstance(DataProcessamento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataProcessamento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataProcessamento
+        self.DataProcessamento = initvalue_
+        self.DataProcessamento_nsprefix_ = None
+        self.ResultadoOperacao = ResultadoOperacao
+        self.ResultadoOperacao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, RetornoConsultaSituacaoGuia)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if RetornoConsultaSituacaoGuia.subclass:
+            return RetornoConsultaSituacaoGuia.subclass(*args_, **kwargs_)
+        else:
+            return RetornoConsultaSituacaoGuia(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumero(self, value):
+        result = True
+        # Validate type tpNumero, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpNumero_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                result = False
+        return result
+    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
+    def has__content(self):
+        if (
+            self.Situacao is not None or
+            self.NumeroGuia is not None or
+            self.DataRecebimento is not None or
+            self.DataProcessamento is not None or
+            self.ResultadoOperacao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaSituacaoGuia', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RetornoConsultaSituacaoGuia')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RetornoConsultaSituacaoGuia':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RetornoConsultaSituacaoGuia')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RetornoConsultaSituacaoGuia', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RetornoConsultaSituacaoGuia'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaSituacaoGuia', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Situacao is not None:
+            namespaceprefix_ = self.Situacao_nsprefix_ + ':' if (UseCapturedNS_ and self.Situacao_nsprefix_) else ''
+            self.Situacao.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Situacao', pretty_print=pretty_print)
+        if self.NumeroGuia is not None:
+            namespaceprefix_ = self.NumeroGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroGuia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroGuia>%s</%sNumeroGuia>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroGuia, input_name='NumeroGuia'), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+        if self.DataProcessamento is not None:
+            namespaceprefix_ = self.DataProcessamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataProcessamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataProcessamento>%s</%sDataProcessamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataProcessamento, input_name='DataProcessamento'), namespaceprefix_ , eol_))
+        if self.ResultadoOperacao is not None:
+            namespaceprefix_ = self.ResultadoOperacao_nsprefix_ + ':' if (UseCapturedNS_ and self.ResultadoOperacao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sResultadoOperacao>%s</%sResultadoOperacao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ResultadoOperacao), input_name='ResultadoOperacao')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Situacao':
+            obj_ = SituacaoType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Signature = obj_
-            obj_.original_tagname_ = 'Signature'
-# end class PedidoCancelamentoLote
+            self.Situacao = obj_
+            obj_.original_tagname_ = 'Situacao'
+        elif nodeName_ == 'NumeroGuia' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'NumeroGuia')
+            ival_ = self.gds_validate_integer(ival_, node, 'NumeroGuia')
+            self.NumeroGuia = ival_
+            self.NumeroGuia_nsprefix_ = child_.prefix
+            # validate type tpNumero
+            self.validate_tpNumero(self.NumeroGuia)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataProcessamento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataProcessamento = dval_
+            self.DataProcessamento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'ResultadoOperacao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ResultadoOperacao')
+            value_ = self.gds_validate_string(value_, node, 'ResultadoOperacao')
+            self.ResultadoOperacao = value_
+            self.ResultadoOperacao_nsprefix_ = child_.prefix
+# end class RetornoConsultaSituacaoGuia
 
 
 class tpEvento(GeneratedsSuper):
@@ -1342,8 +1572,8 @@ class tpEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xs:short'}, None),
-        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xs:string'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 3),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 3),
     ]
@@ -1380,10 +1610,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoEvento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
@@ -1394,10 +1620,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1510,8 +1732,8 @@ class tpCPFCNPJ(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, 4),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, 4),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, 4),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, 4),
     ]
     subclass = None
     superclass = None
@@ -1542,10 +1764,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1556,10 +1774,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1651,10 +1865,10 @@ class tpCPFCNPJNIF(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -1691,10 +1905,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1705,10 +1915,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1719,10 +1925,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1736,12 +1938,8 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1984,10 +2182,10 @@ class tpChaveNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xs:long'}, None),
-        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xsd:long'}, None),
+        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2024,10 +2222,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2038,10 +2232,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2052,10 +2242,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoVerificacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 8:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoVerificacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2069,10 +2255,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -2202,9 +2384,9 @@ class tpChaveRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xs:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xsd:long'}, None),
     ]
     subclass = None
     superclass = None
@@ -2238,10 +2420,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2252,10 +2430,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpSerieRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 5:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpSerieRPS' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2269,10 +2443,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2405,10 +2575,10 @@ class tpEnderecoExterior(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xs:string'}, None),
-        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xs:string'}, None),
-        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xs:string'}, None),
-        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xsd:string'}, None),
+        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xsd:string'}, None),
+        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2445,10 +2615,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -2459,10 +2625,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEndPostal, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 11:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoEndPostal' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2476,10 +2638,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpNomeCidade, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNomeCidade' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2493,10 +2651,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpEstadoProvinciaRegiao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEstadoProvinciaRegiao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2619,8 +2773,8 @@ class tpEnderecoNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xs:int'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xsd:int'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -2651,10 +2805,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2665,10 +2815,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -2762,14 +2908,14 @@ class tpEndereco(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xs:string'}, None),
-        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xs:int'}, None),
-        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xs:string'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xsd:int'}, None),
+        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xsd:int'}, None),
         MemberSpec_('EnderecoExterior', 'tpEnderecoExterior', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoExterior', 'type': 'tpEnderecoExterior'}, None),
     ]
     subclass = None
@@ -2821,10 +2967,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpTipoLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 3:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTipoLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2838,10 +2980,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2855,10 +2993,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2872,10 +3006,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2889,10 +3019,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2906,10 +3032,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2920,10 +3042,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpUF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpUF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2937,10 +3055,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3123,10 +3237,10 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     member_data_items_ = [
         MemberSpec_('endNac', 'tpEnderecoNacional', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endNac', 'type': 'tpEnderecoNacional'}, 5),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 5),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3167,10 +3281,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3184,10 +3294,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3201,10 +3307,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3218,10 +3320,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3362,12 +3460,12 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, 6),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, 6),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 6),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3409,10 +3507,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3423,10 +3517,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3440,10 +3530,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3457,10 +3543,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3474,10 +3556,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3641,14 +3719,14 @@ class tpInformacoesLote(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('DataEnvioLote', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xs:long'}, None),
-        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('DataEnvioLote', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xsd:string'}, None),
+        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xsd:long'}, None),
+        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -3666,11 +3744,7 @@ class tpInformacoesLote(GeneratedsSuper):
         self.InscricaoPrestador_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        if isinstance(DataEnvioLote, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEnvioLote, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEnvioLote
-        self.DataEnvioLote = initvalue_
+        self.DataEnvioLote = DataEnvioLote
         self.DataEnvioLote_nsprefix_ = None
         self.QtdNotasProcessadas = QtdNotasProcessadas
         self.validate_tpQuantidade(self.QtdNotasProcessadas)
@@ -3699,10 +3773,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -3713,10 +3783,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -3727,10 +3793,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpQuantidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
@@ -3741,10 +3803,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpTempoProcessamento, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpTempoProcessamento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpTempoProcessamento_patterns_, ))
@@ -3755,10 +3813,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -3831,7 +3885,7 @@ class tpInformacoesLote(GeneratedsSuper):
         if self.DataEnvioLote is not None:
             namespaceprefix_ = self.DataEnvioLote_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEnvioLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEnvioLote, input_name='DataEnvioLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEnvioLote), input_name='DataEnvioLote')), namespaceprefix_ , eol_))
         if self.QtdNotasProcessadas is not None:
             namespaceprefix_ = self.QtdNotasProcessadas_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdNotasProcessadas_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -3884,9 +3938,10 @@ class tpInformacoesLote(GeneratedsSuper):
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
         elif nodeName_ == 'DataEnvioLote':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEnvioLote = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEnvioLote')
+            value_ = self.gds_validate_string(value_, node, 'DataEnvioLote')
+            self.DataEnvioLote = value_
             self.DataEnvioLote_nsprefix_ = child_.prefix
         elif nodeName_ == 'QtdNotasProcessadas' and child_.text:
             sval_ = child_.text
@@ -3941,13 +3996,13 @@ class tpInformacoesPessoa(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'end', 'type': 'tpEnderecoIBSCBS'}, None),
-        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xs:string'}, None),
+        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3992,10 +4047,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -4006,10 +4057,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -4020,10 +4067,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4037,12 +4080,8 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4052,10 +4091,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4069,10 +4104,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4228,7 +4259,7 @@ class tpGRefNFSe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xs:string'}, None),
+        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4258,10 +4289,6 @@ class tpGRefNFSe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -4446,9 +4473,9 @@ class tpImovelObra(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xs:string'}, None),
-        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xs:string'}, 7),
-        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xs:string'}, 7),
+        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xsd:string'}, None),
+        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xsd:string'}, 7),
+        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xsd:string'}, 7),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, 7),
     ]
     subclass = None
@@ -4485,10 +4512,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpInscImobFisc, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpInscImobFisc' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4502,10 +4525,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCCIB, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCCIB_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCCIB_patterns_, ))
@@ -4516,10 +4535,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCObra, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCObra' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4690,11 +4705,11 @@ class tpDocumento(GeneratedsSuper):
         MemberSpec_('docFiscalOutro', 'tpDocFiscalOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docFiscalOutro', 'type': 'tpDocFiscalOutro'}, 8),
         MemberSpec_('docOutro', 'tpDocOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docOutro', 'type': 'tpDocOutro'}, 8),
         MemberSpec_('fornec', 'tpFornecedor', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'fornec', 'type': 'tpFornecedor'}, None),
-        MemberSpec_('dtEmiDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('dtCompDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xs:int'}, None),
-        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xs:string'}, None),
-        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('dtEmiDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtCompDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xsd:string'}, None),
+        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -4712,17 +4727,9 @@ class tpDocumento(GeneratedsSuper):
         self.docOutro_nsprefix_ = None
         self.fornec = fornec
         self.fornec_nsprefix_ = None
-        if isinstance(dtEmiDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtEmiDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtEmiDoc
-        self.dtEmiDoc = initvalue_
+        self.dtEmiDoc = dtEmiDoc
         self.dtEmiDoc_nsprefix_ = None
-        if isinstance(dtCompDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtCompDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtCompDoc
-        self.dtCompDoc = initvalue_
+        self.dtCompDoc = dtCompDoc
         self.dtCompDoc_nsprefix_ = None
         self.tpReeRepRes = tpReeRepRes
         self.validate_tpReeRepRes(self.tpReeRepRes)
@@ -4748,12 +4755,8 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpReeRepRes, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 99]
+            enumerations = ['1', '2', '3', '4', '99']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4763,10 +4766,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpXTpReeRepRes, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 150:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4780,10 +4779,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -4858,11 +4853,11 @@ class tpDocumento(GeneratedsSuper):
         if self.dtEmiDoc is not None:
             namespaceprefix_ = self.dtEmiDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtEmiDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtEmiDoc, input_name='dtEmiDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtEmiDoc), input_name='dtEmiDoc')), namespaceprefix_ , eol_))
         if self.dtCompDoc is not None:
             namespaceprefix_ = self.dtCompDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtCompDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtCompDoc, input_name='dtCompDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtCompDoc), input_name='dtCompDoc')), namespaceprefix_ , eol_))
         if self.tpReeRepRes is not None:
             namespaceprefix_ = self.tpReeRepRes_nsprefix_ + ':' if (UseCapturedNS_ and self.tpReeRepRes_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -4910,14 +4905,16 @@ class tpDocumento(GeneratedsSuper):
             self.fornec = obj_
             obj_.original_tagname_ = 'fornec'
         elif nodeName_ == 'dtEmiDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtEmiDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtEmiDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtEmiDoc')
+            self.dtEmiDoc = value_
             self.dtEmiDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtCompDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtCompDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtCompDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtCompDoc')
+            self.dtCompDoc = value_
             self.dtCompDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'tpReeRepRes' and child_.text:
             sval_ = child_.text
@@ -4954,9 +4951,9 @@ class tpDFeNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xs:int'}, None),
-        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xs:string'}, None),
-        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xs:string'}, None),
+        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4990,12 +4987,8 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpTipoChaveDFE, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 9]
+            enumerations = ['1', '2', '3', '9']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpTipoChaveDFE' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5005,10 +4998,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpXTipoChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTipoChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5022,10 +5011,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5164,9 +5149,9 @@ class tpDocFiscalOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xs:int'}, None),
-        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xs:string'}, None),
-        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xs:string'}, None),
+        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xsd:int'}, None),
+        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5200,10 +5185,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -5214,10 +5195,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5341,8 +5318,8 @@ class tpDocOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xs:string'}, None),
-        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xs:string'}, None),
+        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5373,10 +5350,6 @@ class tpDocOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5475,11 +5448,11 @@ class tpFornecedor(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5519,10 +5492,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -5533,10 +5502,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -5547,10 +5512,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5564,12 +5525,8 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5579,10 +5536,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5735,9 +5688,9 @@ class tpAtividadeEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xs:string'}, None),
-        MemberSpec_('dtIniEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xs:date'}, None),
-        MemberSpec_('dtFimEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xs:date'}, None),
+        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtIniEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtFimEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, None),
     ]
     subclass = None
@@ -5751,17 +5704,9 @@ class tpAtividadeEvento(GeneratedsSuper):
         self.xNomeEvt = xNomeEvt
         self.validate_tpXNomeEvt(self.xNomeEvt)
         self.xNomeEvt_nsprefix_ = None
-        if isinstance(dtIniEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtIniEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtIniEvt
-        self.dtIniEvt = initvalue_
+        self.dtIniEvt = dtIniEvt
         self.dtIniEvt_nsprefix_ = None
-        if isinstance(dtFimEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtFimEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtFimEvt
-        self.dtFimEvt = initvalue_
+        self.dtFimEvt = dtFimEvt
         self.dtFimEvt_nsprefix_ = None
         self.end = end
         self.end_nsprefix_ = None
@@ -5780,10 +5725,6 @@ class tpAtividadeEvento(GeneratedsSuper):
         result = True
         # Validate type tpXNomeEvt, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXNomeEvt' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5840,11 +5781,11 @@ class tpAtividadeEvento(GeneratedsSuper):
         if self.dtIniEvt is not None:
             namespaceprefix_ = self.dtIniEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtIniEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtIniEvt, input_name='dtIniEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtIniEvt), input_name='dtIniEvt')), namespaceprefix_ , eol_))
         if self.dtFimEvt is not None:
             namespaceprefix_ = self.dtFimEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFimEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFimEvt, input_name='dtFimEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtFimEvt), input_name='dtFimEvt')), namespaceprefix_ , eol_))
         if self.end is not None:
             namespaceprefix_ = self.end_nsprefix_ + ':' if (UseCapturedNS_ and self.end_nsprefix_) else ''
             self.end.export(outfile, level, namespaceprefix_, namespacedef_='', name_='end', pretty_print=pretty_print)
@@ -5871,14 +5812,16 @@ class tpAtividadeEvento(GeneratedsSuper):
             # validate type tpXNomeEvt
             self.validate_tpXNomeEvt(self.xNomeEvt)
         elif nodeName_ == 'dtIniEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtIniEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtIniEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtIniEvt')
+            self.dtIniEvt = value_
             self.dtIniEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtFimEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtFimEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtFimEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtFimEvt')
+            self.dtFimEvt = value_
             self.dtFimEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'end':
             obj_ = tpEnderecoSimplesIBSCBS.factory(parent_object_=self)
@@ -5960,13 +5903,13 @@ class tpIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xs:int'}, None),
-        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xs:int'}, None),
-        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xs:string'}, None),
-        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xs:int'}, None),
+        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xsd:int'}, None),
+        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xsd:int'}, None),
+        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xsd:int'}, None),
         MemberSpec_('gRefNFSe', 'tpGRefNFSe', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gRefNFSe', 'type': 'tpGRefNFSe'}, None),
-        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xs:int'}, None),
-        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xs:int'}, None),
+        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xsd:int'}, None),
+        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xsd:int'}, None),
         MemberSpec_('dest', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'dest', 'type': 'tpInformacoesPessoa'}, None),
         MemberSpec_('valores', 'tpValores', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'valores', 'type': 'tpValores'}, None),
         MemberSpec_('imovelobra', 'tpImovelObra', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'imovelobra', 'type': 'tpImovelObra'}, None),
@@ -6020,12 +5963,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpFinNFSe, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0]
+            enumerations = ['0']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpFinNFSe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6035,12 +5974,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6055,10 +5990,6 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCIndOp, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCIndOp_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCIndOp_patterns_, ))
@@ -6069,12 +6000,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpOper, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 5]
+            enumerations = ['1', '2', '3', '4', '5']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpOper' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6084,12 +6011,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpEnteGov, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4]
+            enumerations = ['1', '2', '3', '4']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEnteGov' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6099,12 +6022,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpIndDest, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpIndDest' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6296,7 +6215,7 @@ class tpGIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xsd:string'}, None),
         MemberSpec_('gTribRegular', 'tpGTribRegular', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gTribRegular', 'type': 'tpGTribRegular'}, None),
     ]
     subclass = None
@@ -6327,10 +6246,6 @@ class tpGIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6434,7 +6349,7 @@ class tpGTribRegular(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -6462,10 +6377,6 @@ class tpGTribRegular(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6693,45 +6604,45 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Adquirente', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Adquirente', 'type': 'tpInformacoesPessoa'}, None),
-        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xs:decimal'}, None),
+        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -6875,10 +6786,6 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -7935,67 +7842,67 @@ class tpNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, None),
-        MemberSpec_('DataEmissaoNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('DataEmissaoNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissaoRPS', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xs:date'}, None),
-        MemberSpec_('DataFatoGeradorNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xs:dateTime'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissaoRPS', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataFatoGeradorNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJPrestador', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJPrestador', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xs:string'}, None),
+        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoPrestador', 'tpEndereco', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'EnderecoPrestador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xs:string'}, None),
-        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('DataCancelamento', 'xs:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xs:long'}, None),
-        MemberSpec_('DataQuitacaoGuia', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xs:date'}, None),
-        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataQuitacaoGuia', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
         MemberSpec_('RetornoComplementarIBSCBS', 'tpRetornoComplementarIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RetornoComplementarIBSCBS', 'type': 'tpRetornoComplementarIBSCBS'}, None),
     ]
@@ -8012,11 +7919,7 @@ class tpNFe(GeneratedsSuper):
         self.Assinatura_nsprefix_ = None
         self.ChaveNFe = ChaveNFe
         self.ChaveNFe_nsprefix_ = None
-        if isinstance(DataEmissaoNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEmissaoNFe
-        self.DataEmissaoNFe = initvalue_
+        self.DataEmissaoNFe = DataEmissaoNFe
         self.DataEmissaoNFe_nsprefix_ = None
         self.NumeroLote = NumeroLote
         self.validate_tpNumero(self.NumeroLote)
@@ -8026,17 +7929,9 @@ class tpNFe(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissaoRPS, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoRPS, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissaoRPS
-        self.DataEmissaoRPS = initvalue_
+        self.DataEmissaoRPS = DataEmissaoRPS
         self.DataEmissaoRPS_nsprefix_ = None
-        if isinstance(DataFatoGeradorNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataFatoGeradorNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataFatoGeradorNFe
-        self.DataFatoGeradorNFe = initvalue_
+        self.DataFatoGeradorNFe = DataFatoGeradorNFe
         self.DataFatoGeradorNFe_nsprefix_ = None
         self.CPFCNPJPrestador = CPFCNPJPrestador
         self.CPFCNPJPrestador_nsprefix_ = None
@@ -8051,11 +7946,7 @@ class tpNFe(GeneratedsSuper):
         self.StatusNFe = StatusNFe
         self.validate_tpStatusNFe(self.StatusNFe)
         self.StatusNFe_nsprefix_ = None
-        if isinstance(DataCancelamento, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataCancelamento
-        self.DataCancelamento = initvalue_
+        self.DataCancelamento = DataCancelamento
         self.DataCancelamento_nsprefix_ = None
         self.TributacaoNFe = TributacaoNFe
         self.validate_tpTributacaoNFe(self.TributacaoNFe)
@@ -8066,11 +7957,7 @@ class tpNFe(GeneratedsSuper):
         self.NumeroGuia = NumeroGuia
         self.validate_tpNumero(self.NumeroGuia)
         self.NumeroGuia_nsprefix_ = None
-        if isinstance(DataQuitacaoGuia, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataQuitacaoGuia, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataQuitacaoGuia
-        self.DataQuitacaoGuia = initvalue_
+        self.DataQuitacaoGuia = DataQuitacaoGuia
         self.DataQuitacaoGuia_nsprefix_ = None
         self.ValorServicos = ValorServicos
         self.validate_tpValor(self.ValorServicos)
@@ -8220,10 +8107,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -8234,10 +8117,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -8249,10 +8128,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8266,10 +8141,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8283,10 +8154,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -8298,10 +8165,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8315,10 +8178,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpOpcaoSimples, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['0', '1', '2', '3', '4', '6']
             if value not in enumerations:
@@ -8330,10 +8189,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -8352,10 +8207,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -8366,10 +8217,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -8383,10 +8230,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -8397,10 +8240,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -8411,10 +8250,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8428,10 +8263,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -8445,10 +8276,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8462,10 +8289,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -8476,12 +8299,8 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8496,10 +8315,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -8510,10 +8325,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -8524,10 +8335,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -8643,7 +8450,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoNFe is not None:
             namespaceprefix_ = self.DataEmissaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEmissaoNFe, input_name='DataEmissaoNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoNFe), input_name='DataEmissaoNFe')), namespaceprefix_ , eol_))
         if self.NumeroLote is not None:
             namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8658,11 +8465,11 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoRPS is not None:
             namespaceprefix_ = self.DataEmissaoRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissaoRPS, input_name='DataEmissaoRPS'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoRPS), input_name='DataEmissaoRPS')), namespaceprefix_ , eol_))
         if self.DataFatoGeradorNFe is not None:
             namespaceprefix_ = self.DataFatoGeradorNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataFatoGeradorNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataFatoGeradorNFe, input_name='DataFatoGeradorNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataFatoGeradorNFe), input_name='DataFatoGeradorNFe')), namespaceprefix_ , eol_))
         if self.CPFCNPJPrestador is not None:
             namespaceprefix_ = self.CPFCNPJPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJPrestador_nsprefix_) else ''
             self.CPFCNPJPrestador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJPrestador', pretty_print=pretty_print)
@@ -8684,7 +8491,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataCancelamento is not None:
             namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataCancelamento), input_name='DataCancelamento')), namespaceprefix_ , eol_))
         if self.TributacaoNFe is not None:
             namespaceprefix_ = self.TributacaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.TributacaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8700,7 +8507,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataQuitacaoGuia is not None:
             namespaceprefix_ = self.DataQuitacaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacaoGuia_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacaoGuia, input_name='DataQuitacaoGuia'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataQuitacaoGuia), input_name='DataQuitacaoGuia')), namespaceprefix_ , eol_))
         if self.ValorServicos is not None:
             namespaceprefix_ = self.ValorServicos_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorServicos_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8748,7 +8555,7 @@ class tpNFe(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -8909,9 +8716,10 @@ class tpNFe(GeneratedsSuper):
             self.ChaveNFe = obj_
             obj_.original_tagname_ = 'ChaveNFe'
         elif nodeName_ == 'DataEmissaoNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEmissaoNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoNFe')
+            self.DataEmissaoNFe = value_
             self.DataEmissaoNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'NumeroLote' and child_.text:
             sval_ = child_.text
@@ -8935,14 +8743,16 @@ class tpNFe(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissaoRPS':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissaoRPS = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoRPS')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoRPS')
+            self.DataEmissaoRPS = value_
             self.DataEmissaoRPS_nsprefix_ = child_.prefix
         elif nodeName_ == 'DataFatoGeradorNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataFatoGeradorNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataFatoGeradorNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataFatoGeradorNFe')
+            self.DataFatoGeradorNFe = value_
             self.DataFatoGeradorNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJPrestador':
             obj_ = tpCPFCNPJ.factory(parent_object_=self)
@@ -8979,9 +8789,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpStatusNFe
             self.validate_tpStatusNFe(self.StatusNFe)
         elif nodeName_ == 'DataCancelamento':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataCancelamento = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataCancelamento')
+            value_ = self.gds_validate_string(value_, node, 'DataCancelamento')
+            self.DataCancelamento = value_
             self.DataCancelamento_nsprefix_ = child_.prefix
         elif nodeName_ == 'TributacaoNFe':
             value_ = child_.text
@@ -9008,9 +8819,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpNumero
             self.validate_tpNumero(self.NumeroGuia)
         elif nodeName_ == 'DataQuitacaoGuia':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataQuitacaoGuia = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataQuitacaoGuia')
+            value_ = self.gds_validate_string(value_, node, 'DataQuitacaoGuia')
+            self.DataQuitacaoGuia = value_
             self.DataQuitacaoGuia_nsprefix_ = child_.prefix
         elif nodeName_ == 'ValorServicos' and child_.text:
             sval_ = child_.text
@@ -9101,10 +8913,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpValor
             self.validate_tpValor(self.ValorCredito)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -9426,8 +9238,7 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipalTomador esteja pre
-    enchido.
+    ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9657,52 +9468,52 @@ class tpRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissao', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xs:date'}, None),
-        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissao', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
     ]
     subclass = None
@@ -9721,11 +9532,7 @@ class tpRPS(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissao, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissao
-        self.DataEmissao = initvalue_
+        self.DataEmissao = DataEmissao
         self.DataEmissao_nsprefix_ = None
         self.StatusRPS = StatusRPS
         self.validate_tpStatusNFe(self.StatusRPS)
@@ -9870,10 +9677,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -9885,10 +9688,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -9900,10 +9699,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -9917,10 +9712,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -9939,10 +9730,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -9953,10 +9740,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -9970,10 +9753,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -9984,10 +9763,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -9998,10 +9773,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10015,10 +9786,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10032,10 +9799,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10049,10 +9812,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -10066,10 +9825,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10083,10 +9838,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -10097,10 +9848,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -10111,12 +9858,8 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10131,10 +9874,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -10145,10 +9884,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -10159,10 +9894,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -10266,7 +9997,7 @@ class tpRPS(GeneratedsSuper):
         if self.DataEmissao is not None:
             namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissao), input_name='DataEmissao')), namespaceprefix_ , eol_))
         if self.StatusRPS is not None:
             namespaceprefix_ = self.StatusRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.StatusRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -10310,7 +10041,7 @@ class tpRPS(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -10476,9 +10207,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissao':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissao = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissao')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissao')
+            self.DataEmissao = value_
             self.DataEmissao_nsprefix_ = child_.prefix
         elif nodeName_ == 'StatusRPS':
             value_ = child_.text
@@ -10561,10 +10293,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpAliquota
             self.validate_tpAliquota(self.AliquotaServicos)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -10811,7 +10543,7 @@ class tpRPS(GeneratedsSuper):
 class SignatureType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('SignedInfo', 'SignedInfoType', 0, 0, {'name': 'SignedInfo', 'type': 'SignedInfoType'}, None),
         MemberSpec_('SignatureValue', 'SignatureValueType', 0, 0, {'name': 'SignatureValue', 'type': 'SignatureValueType'}, None),
         MemberSpec_('KeyInfo', 'KeyInfoType', 0, 0, {'name': 'KeyInfo', 'type': 'KeyInfoType'}, None),
@@ -10878,7 +10610,7 @@ class SignatureType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -10931,8 +10663,8 @@ class SignatureType(GeneratedsSuper):
 class SignatureValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
-        MemberSpec_('valueOf_', 'xs:base64Binary', 0),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('valueOf_', 'base64Binary', 0),
     ]
     subclass = None
     superclass = None
@@ -10986,7 +10718,7 @@ class SignatureValueType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureValueType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureValueType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -11014,7 +10746,7 @@ class SignatureValueType(GeneratedsSuper):
 class SignedInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('CanonicalizationMethod', 'CanonicalizationMethodType', 0, 0, {'name': 'CanonicalizationMethod', 'type': 'CanonicalizationMethodType'}, None),
         MemberSpec_('SignatureMethod', 'SignatureMethodType', 0, 0, {'name': 'SignatureMethod', 'type': 'SignatureMethodType'}, None),
         MemberSpec_('Reference', 'ReferenceType', 1, 0, {'maxOccurs': 'unbounded', 'name': 'Reference', 'type': 'ReferenceType'}, None),
@@ -11084,7 +10816,7 @@ class SignedInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignedInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignedInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11137,12 +10869,12 @@ class SignedInfoType(GeneratedsSuper):
 class ReferenceType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('URI', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'URI'}),
         MemberSpec_('Type', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'Type'}),
         MemberSpec_('Transforms', 'TransformsType', 0, 0, {'name': 'Transforms', 'type': 'TransformsType'}, None),
         MemberSpec_('DigestMethod', 'DigestMethodType', 0, 0, {'name': 'DigestMethod', 'type': 'DigestMethodType'}, None),
-        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -11217,13 +10949,13 @@ class ReferenceType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='ReferenceType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
         if self.URI is not None and 'URI' not in already_processed:
             already_processed.add('URI')
-            outfile.write(' URI=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.URI), input_name='URI')), ))
+            outfile.write(' URI=%s' % (quote_attrib(self.URI), ))
         if self.Type is not None and 'Type' not in already_processed:
             already_processed.add('Type')
-            outfile.write(' Type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Type), input_name='Type')), ))
+            outfile.write(' Type=%s' % (quote_attrib(self.Type), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='ReferenceType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11386,7 +11118,7 @@ class TransformType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Algorithm', 'xs:anyURI', 0, 0, {'use': 'required', 'name': 'Algorithm'}),
-        MemberSpec_('XPath', 'xs:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xs:string'}, None),
+        MemberSpec_('XPath', 'xsd:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11402,7 +11134,7 @@ class TransformType(GeneratedsSuper):
             self.XPath = []
         else:
             self.XPath = XPath
-        self.XPath_nsprefix_ = None
+        self.XPath_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11447,7 +11179,7 @@ class TransformType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='TransformType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='TransformType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11486,7 +11218,7 @@ class TransformType(GeneratedsSuper):
 class KeyInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('X509Data', 'X509DataType', 0, 0, {'name': 'X509Data', 'type': 'X509DataType'}, None),
     ]
     subclass = None
@@ -11545,7 +11277,7 @@ class KeyInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='KeyInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='KeyInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11670,7 +11402,7 @@ class KeyValueType(GeneratedsSuper):
 class X509DataType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('X509Certificate', 'xs:base64Binary', 0, 0, {'name': 'X509Certificate', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('X509Certificate', 'xsd:string', 0, 0, {'name': 'X509Certificate', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11681,7 +11413,7 @@ class X509DataType(GeneratedsSuper):
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
         self.X509Certificate = X509Certificate
-        self.X509Certificate_nsprefix_ = None
+        self.X509Certificate_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11733,7 +11465,7 @@ class X509DataType(GeneratedsSuper):
         if self.X509Certificate is not None:
             namespaceprefix_ = self.X509Certificate_nsprefix_ + ':' if (UseCapturedNS_ and self.X509Certificate_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_format_base64(self.X509Certificate, input_name='X509Certificate'), namespaceprefix_ , eol_))
+            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.X509Certificate), input_name='X509Certificate')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11749,137 +11481,123 @@ class X509DataType(GeneratedsSuper):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if nodeName_ == 'X509Certificate':
-            sval_ = child_.text
-            if sval_ is not None:
-                try:
-                    bval_ = base64.b64decode(sval_)
-                except (TypeError, ValueError) as exp:
-                    raise_parse_error(child_, 'requires base64 encoded string: %s' % exp)
-                bval_ = self.gds_validate_base64(bval_, node, 'X509Certificate')
-            else:
-                bval_ = None
-            self.X509Certificate = bval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'X509Certificate')
+            value_ = self.gds_validate_string(value_, node, 'X509Certificate')
+            self.X509Certificate = value_
             self.X509Certificate_nsprefix_ = child_.prefix
 # end class X509DataType
 
 
-class CabecalhoType(GeneratedsSuper):
-    """CabecalhoType -- Cabe
+class tpEventoAsync(GeneratedsSuper):
+    """Codigo -- C
+    ó
+    digo do evento.
+    Descricao -- Descri
     ç
-    alho do pedido de cancelamento de lote.
-    Versao -- Informe a Vers
     ã
-    o do Schema XML utilizado.
-    CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-    NumeroLote -- Informe o n
-    ú
-    mero do Lote a ser cancelado.
+    o do evento.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
-        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, NumeroLote=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Codigo=None, Descricao=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
-        self.Versao = _cast(None, Versao)
-        self.Versao_nsprefix_ = None
-        self.CPFCNPJRemetente = CPFCNPJRemetente
-        self.CPFCNPJRemetente_nsprefix_ = None
-        self.NumeroLote = NumeroLote
-        self.validate_tpNumero(self.NumeroLote)
-        self.NumeroLote_nsprefix_ = None
+        self.Codigo = Codigo
+        self.validate_tpCodigoEvento(self.Codigo)
+        self.Codigo_nsprefix_ = None
+        self.Descricao = Descricao
+        self.validate_tpDescricaoEvento(self.Descricao)
+        self.Descricao_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, CabecalhoType)
+                CurrentSubclassModule_, tpEventoAsync)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if CabecalhoType.subclass:
-            return CabecalhoType.subclass(*args_, **kwargs_)
+        if tpEventoAsync.subclass:
+            return tpEventoAsync.subclass(*args_, **kwargs_)
         else:
-            return CabecalhoType(*args_, **kwargs_)
+            return tpEventoAsync(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def validate_tpNumero(self, value):
+    def validate_tpCodigoEvento(self, value):
         result = True
-        # Validate type tpNumero, a restriction on xs:long.
+        # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
-                    self.validate_tpNumero_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                    self.validate_tpCodigoEvento_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
                 result = False
         return result
-    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
-    def validate_tpVersao(self, value):
-        # Validate type tipos:tpVersao, a restriction on xs:long.
+    validate_tpCodigoEvento_patterns_ = [['^([0-9]{3,4})$']]
+    def validate_tpDescricaoEvento(self, value):
+        result = True
+        # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
+            if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
-            if not self.gds_validate_simple_patterns(
-                    self.validate_tpVersao_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpVersao_patterns_, ))
-    validate_tpVersao_patterns_ = [['^([0-9]{1,3})$']]
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
     def has__content(self):
         if (
-            self.CPFCNPJRemetente is not None or
-            self.NumeroLote is not None
+            self.Codigo is not None or
+            self.Descricao is not None
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('CabecalhoType')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpEventoAsync')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'CabecalhoType':
+        if self.original_tagname_ is not None and name_ == 'tpEventoAsync':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='CabecalhoType')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpEventoAsync')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='CabecalhoType', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpEventoAsync', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CabecalhoType'):
-        if self.Versao is not None and 'Versao' not in already_processed:
-            already_processed.add('Versao')
-            outfile.write(' Versao="%s"' % self.gds_format_integer(self.Versao, input_name='Versao'))
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', fromsubclass_=False, pretty_print=True):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpEventoAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.CPFCNPJRemetente is not None:
-            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
-            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
-        if self.NumeroLote is not None:
-            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+        if self.Codigo is not None:
+            namespaceprefix_ = self.Codigo_nsprefix_ + ':' if (UseCapturedNS_ and self.Codigo_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sCodigo>%s</%sCodigo>%s' % (namespaceprefix_ , self.gds_format_integer(self.Codigo, input_name='Codigo'), namespaceprefix_ , eol_))
+        if self.Descricao is not None:
+            namespaceprefix_ = self.Descricao_nsprefix_ + ':' if (UseCapturedNS_ and self.Descricao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDescricao>%s</%sDescricao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Descricao), input_name='Descricao')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11892,26 +11610,386 @@ class CabecalhoType(GeneratedsSuper):
             self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
         return self
     def _buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('Versao', node)
-        if value is not None and 'Versao' not in already_processed:
-            already_processed.add('Versao')
-            self.Versao = self.gds_parse_integer(value, node, 'Versao')
-            self.validate_tpVersao(self.Versao)    # validate type tpVersao
+        pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'CPFCNPJRemetente':
-            obj_ = tpCPFCNPJ.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.CPFCNPJRemetente = obj_
-            obj_.original_tagname_ = 'CPFCNPJRemetente'
-        elif nodeName_ == 'NumeroLote' and child_.text:
+        if nodeName_ == 'Codigo' and child_.text:
             sval_ = child_.text
-            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
-            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
-            self.NumeroLote = ival_
-            self.NumeroLote_nsprefix_ = child_.prefix
-            # validate type tpNumero
-            self.validate_tpNumero(self.NumeroLote)
-# end class CabecalhoType
+            ival_ = self.gds_parse_integer(sval_, node, 'Codigo')
+            ival_ = self.gds_validate_integer(ival_, node, 'Codigo')
+            self.Codigo = ival_
+            self.Codigo_nsprefix_ = child_.prefix
+            # validate type tpCodigoEvento
+            self.validate_tpCodigoEvento(self.Codigo)
+        elif nodeName_ == 'Descricao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Descricao')
+            value_ = self.gds_validate_string(value_, node, 'Descricao')
+            self.Descricao = value_
+            self.Descricao_nsprefix_ = child_.prefix
+            # validate type tpDescricaoEvento
+            self.validate_tpDescricaoEvento(self.Descricao)
+# end class tpEventoAsync
+
+
+class tpInformacoesLoteAsync(GeneratedsSuper):
+    """tpInformacoesLoteAsync -- Informa
+    ç
+    õ
+    es do lote processado.
+    NumeroProtocolo -- N
+    ú
+    mero do protocolo do lote.
+    DataRecebimento -- Data/hora de envio do lote.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesLoteAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesLoteAsync.subclass:
+            return tpInformacoesLoteAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesLoteAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesLoteAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesLoteAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesLoteAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesLoteAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesLoteAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesLoteAsync
+
+
+class tpInformacoesGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesGuiaAsync.subclass:
+            return tpInformacoesGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesGuiaAsync
+
+
+class SituacaoType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('nome', 'async:tpSituacaoGuia', 0, 1, {'use': 'optional', 'name': 'nome'}),
+        MemberSpec_('valueOf_', 'xsd:int', 0),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, nome=None, valueOf_=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.nome = _cast(None, nome)
+        self.nome_nsprefix_ = None
+        self.valueOf_ = valueOf_
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, SituacaoType)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if SituacaoType.subclass:
+            return SituacaoType.subclass(*args_, **kwargs_)
+        else:
+            return SituacaoType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpSituacaoGuia(self, value):
+        # Validate type async:tpSituacaoGuia, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = ['solicitada', 'invalidada', 'verificada', 'processada']
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpSituacaoGuia' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+    def has__content(self):
+        if (
+            (1 if type(self.valueOf_) in [int,float] else self.valueOf_)
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SituacaoType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('SituacaoType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'SituacaoType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='SituacaoType')
+        outfile.write('>')
+        self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_, pretty_print=pretty_print)
+        outfile.write(self.convert_unicode(self.valueOf_))
+        outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SituacaoType'):
+        if self.nome is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            outfile.write(' nome=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.nome), input_name='nome')), ))
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SituacaoType', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        self.valueOf_ = get_all_text_(node)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('nome', node)
+        if value is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            self.nome = value
+            self.validate_tpSituacaoGuia(self.nome)    # validate type tpSituacaoGuia
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        pass
+# end class SituacaoType
 
 
 class CanonicalizationMethodType(GeneratedsSuper):
@@ -11972,7 +12050,7 @@ class CanonicalizationMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CanonicalizationMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CanonicalizationMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12054,7 +12132,7 @@ class SignatureMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SignatureMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SignatureMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12136,7 +12214,7 @@ class DigestMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DigestMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DigestMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12163,8 +12241,8 @@ class DigestMethodType(GeneratedsSuper):
 class RSAKeyValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xs:base64Binary'}, None),
-        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xsd:base64Binary'}, None),
+        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -12342,8 +12420,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoGuia'
+        rootClass = PedidoConsultaSituacaoGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12374,8 +12452,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoGuia'
+        rootClass = PedidoConsultaSituacaoGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12420,8 +12498,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoGuia'
+        rootClass = PedidoConsultaSituacaoGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12448,8 +12526,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoGuia'
+        rootClass = PedidoConsultaSituacaoGuia
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12457,8 +12535,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoCancelamentoLote import *\n\n')
-        sys.stdout.write('import PedidoCancelamentoLote as model_\n\n')
+        sys.stdout.write('#from ConsultaSituacaoGuiaAsync import *\n\n')
+        sys.stdout.write('import ConsultaSituacaoGuiaAsync as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12773,6 +12851,30 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                                 'CT'),
                                                ('tpRPS',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
+                                                'CT'),
+                                               ('tpNumeroProtocoloAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpIncidencia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoLote',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEmissaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEventoAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesLoteAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesGuiaAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
                                                 'CT')],
  'http://www.w3.org/2000/09/xmldsig#': [('CryptoBinary',
                                          'schemas/nfse/xmldsig-core-schema_v02.xsd',
@@ -12809,18 +12911,19 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                          'CT')]}
 
 __all__ = [
-    "CabecalhoType",
     "CanonicalizationMethodType",
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoCancelamentoLote",
+    "PedidoConsultaSituacaoGuia",
     "RSAKeyValueType",
     "ReferenceType",
+    "RetornoConsultaSituacaoGuia",
     "SignatureMethodType",
     "SignatureType",
     "SignatureValueType",
     "SignedInfoType",
+    "SituacaoType",
     "TransformType",
     "TransformsType",
     "X509DataType",
@@ -12840,6 +12943,7 @@ __all__ = [
     "tpEnderecoNacional",
     "tpEnderecoSimplesIBSCBS",
     "tpEvento",
+    "tpEventoAsync",
     "tpFornecedor",
     "tpGIBSCBS",
     "tpGRefNFSe",
@@ -12847,7 +12951,9 @@ __all__ = [
     "tpGrupoReeRepRes",
     "tpIBSCBS",
     "tpImovelObra",
+    "tpInformacoesGuiaAsync",
     "tpInformacoesLote",
+    "tpInformacoesLoteAsync",
     "tpInformacoesPessoa",
     "tpNFe",
     "tpRPS",

--- a/nfselib/paulistana/v03/ConsultaSituacaoLoteAsync.py
+++ b/nfselib/paulistana/v03/ConsultaSituacaoLoteAsync.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoCancelamentoLote.py')
+#   ('-o', 'nfselib/paulistana/v03/ConsultaSituacaoLoteAsync.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   schemas/nfse/ConsultaSituacaoLoteAsync_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoLote.py" schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/ConsultaSituacaoLoteAsync.py" schemas/nfse/ConsultaSituacaoLoteAsync_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1008,6 +1008,17 @@ def _cast(typ, value):
 #
 # Start enum classes
 #
+class tpEmissaoGuia(str, Enum):
+    _1='1' # Guia de NFS-e emitidas
+    _2='2' # Guia de NFS-e recebidas (exceto rejeitadas)
+    _3='3' # Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)
+    _4='4' # Guia de NFS-e recebidas aceitas
+    _5='5' # Guia de NFS-e recebidas sem manifestação do tomador
+    _6='6' # Guia de NFS-e recebidas rejeitadas
+    _7='7' # Guia de NFTS emitidas
+    _8='8' # Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)
+
+
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
     
@@ -1162,6 +1173,42 @@ class tpReferencia(str, Enum):
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
 
 
+class tpSituacaoGuia(str, Enum):
+    """tpSituacaoGuia -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es da emiss
+    ã
+    o de guia ass
+    í
+    ncrona.
+    
+    """
+    SOLICITADA='solicitada' # Emissao solicitada (0).
+    INVALIDADA='invalidada' # Emissao invalidada (1).
+    VERIFICADA='verificada' # Emissao verificada (2).
+    PROCESSADA='processada' # Emissao processada (3).
+
+
+class tpSituacaoLote(str, Enum):
+    """tpSituacaoLote -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es do lote ass
+    í
+    ncrono.
+    
+    """
+    ENVIADO='enviado' # Lote enviado (0).
+    INVALIDADO='invalidado' # Lote invalidado (1).
+    VERIFICADO='verificado' # Lote verificado (2).
+    PROCESSADO='processado' # Lote processado (3).
+
+
 class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
@@ -1211,91 +1258,101 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoCancelamentoLote(GeneratedsSuper):
-    """PedidoCancelamentoLote -- Schema utilizado para PEDIDO de cancelamento de lote.
-    Este Schema XML
-    é
-    utilizado pelos prestadores de servi
-    ç
-    os cancelarem as NFS-e geradas a partir de um lote de RPS.
-    Cabecalho -- Cabe
-    ç
-    alho do pedido de cancelamento de lote.
-    Signature -- Assinatura digital do CNPJ emissor dos RPS.
+class PedidoConsultaSituacaoLote(GeneratedsSuper):
+    """CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
-        MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
+        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, CPFCNPJRemetente=None, NumeroProtocolo=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
-        self.Cabecalho = Cabecalho
-        self.Cabecalho_nsprefix_ = None
-        self.Signature = Signature
-        self.Signature_nsprefix_ = None
+        self.CPFCNPJRemetente = CPFCNPJRemetente
+        self.CPFCNPJRemetente_nsprefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoCancelamentoLote)
+                CurrentSubclassModule_, PedidoConsultaSituacaoLote)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoCancelamentoLote.subclass:
-            return PedidoCancelamentoLote.subclass(*args_, **kwargs_)
+        if PedidoConsultaSituacaoLote.subclass:
+            return PedidoConsultaSituacaoLote.subclass(*args_, **kwargs_)
         else:
-            return PedidoCancelamentoLote(*args_, **kwargs_)
+            return PedidoConsultaSituacaoLote(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
     def has__content(self):
         if (
-            self.Cabecalho is not None or
-            self.Signature is not None
+            self.CPFCNPJRemetente is not None or
+            self.NumeroProtocolo is not None
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoCancelamentoLote')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaSituacaoLote', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoConsultaSituacaoLote')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoCancelamentoLote':
+        if self.original_tagname_ is not None and name_ == 'PedidoConsultaSituacaoLote':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoCancelamentoLote')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoConsultaSituacaoLote')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoCancelamentoLote', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoConsultaSituacaoLote', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoCancelamentoLote'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoConsultaSituacaoLote'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoConsultaSituacaoLote', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.Cabecalho is not None:
-            namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
-            self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
-        if self.Signature is not None:
-            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
-            self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+        if self.CPFCNPJRemetente is not None:
+            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
+            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -1310,17 +1367,190 @@ class PedidoCancelamentoLote(GeneratedsSuper):
     def _buildAttributes(self, node, attrs, already_processed):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'Cabecalho':
-            obj_ = CabecalhoType.factory(parent_object_=self)
+        if nodeName_ == 'CPFCNPJRemetente':
+            obj_ = tpCPFCNPJ.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Cabecalho = obj_
-            obj_.original_tagname_ = 'Cabecalho'
-        elif nodeName_ == 'Signature':
-            obj_ = SignatureType.factory(parent_object_=self)
+            self.CPFCNPJRemetente = obj_
+            obj_.original_tagname_ = 'CPFCNPJRemetente'
+        elif nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+# end class PedidoConsultaSituacaoLote
+
+
+class RetornoConsultaSituacaoLote(GeneratedsSuper):
+    """NumeroLote -- N
+    ú
+    mero do lote ap
+    ó
+    s processamento.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Situacao', 'SituacaoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Situacao', 'type': 'SituacaoType'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+        MemberSpec_('DataProcessamento', 'xsd:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataProcessamento', 'type': 'xsd:dateTime'}, None),
+        MemberSpec_('ResultadoOperacao', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ResultadoOperacao', 'type': 'xsd:string'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Situacao=None, NumeroLote=None, DataRecebimento=None, DataProcessamento=None, ResultadoOperacao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.Situacao = Situacao
+        self.Situacao_nsprefix_ = None
+        self.NumeroLote = NumeroLote
+        self.validate_tpNumero(self.NumeroLote)
+        self.NumeroLote_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+        if isinstance(DataProcessamento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataProcessamento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataProcessamento
+        self.DataProcessamento = initvalue_
+        self.DataProcessamento_nsprefix_ = None
+        self.ResultadoOperacao = ResultadoOperacao
+        self.ResultadoOperacao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, RetornoConsultaSituacaoLote)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if RetornoConsultaSituacaoLote.subclass:
+            return RetornoConsultaSituacaoLote.subclass(*args_, **kwargs_)
+        else:
+            return RetornoConsultaSituacaoLote(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumero(self, value):
+        result = True
+        # Validate type tpNumero, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpNumero_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                result = False
+        return result
+    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
+    def has__content(self):
+        if (
+            self.Situacao is not None or
+            self.NumeroLote is not None or
+            self.DataRecebimento is not None or
+            self.DataProcessamento is not None or
+            self.ResultadoOperacao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaSituacaoLote', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RetornoConsultaSituacaoLote')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'RetornoConsultaSituacaoLote':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RetornoConsultaSituacaoLote')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RetornoConsultaSituacaoLote', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RetornoConsultaSituacaoLote'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoConsultaSituacaoLote', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Situacao is not None:
+            namespaceprefix_ = self.Situacao_nsprefix_ + ':' if (UseCapturedNS_ and self.Situacao_nsprefix_) else ''
+            self.Situacao.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Situacao', pretty_print=pretty_print)
+        if self.NumeroLote is not None:
+            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+        if self.DataProcessamento is not None:
+            namespaceprefix_ = self.DataProcessamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataProcessamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataProcessamento>%s</%sDataProcessamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataProcessamento, input_name='DataProcessamento'), namespaceprefix_ , eol_))
+        if self.ResultadoOperacao is not None:
+            namespaceprefix_ = self.ResultadoOperacao_nsprefix_ + ':' if (UseCapturedNS_ and self.ResultadoOperacao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sResultadoOperacao>%s</%sResultadoOperacao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ResultadoOperacao), input_name='ResultadoOperacao')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Situacao':
+            obj_ = SituacaoType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Signature = obj_
-            obj_.original_tagname_ = 'Signature'
-# end class PedidoCancelamentoLote
+            self.Situacao = obj_
+            obj_.original_tagname_ = 'Situacao'
+        elif nodeName_ == 'NumeroLote' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
+            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
+            self.NumeroLote = ival_
+            self.NumeroLote_nsprefix_ = child_.prefix
+            # validate type tpNumero
+            self.validate_tpNumero(self.NumeroLote)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'DataProcessamento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataProcessamento = dval_
+            self.DataProcessamento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'ResultadoOperacao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ResultadoOperacao')
+            value_ = self.gds_validate_string(value_, node, 'ResultadoOperacao')
+            self.ResultadoOperacao = value_
+            self.ResultadoOperacao_nsprefix_ = child_.prefix
+# end class RetornoConsultaSituacaoLote
 
 
 class tpEvento(GeneratedsSuper):
@@ -1342,8 +1572,8 @@ class tpEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xs:short'}, None),
-        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xs:string'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 3),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 3),
     ]
@@ -1380,10 +1610,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoEvento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
@@ -1394,10 +1620,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1510,8 +1732,8 @@ class tpCPFCNPJ(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, 4),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, 4),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, 4),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, 4),
     ]
     subclass = None
     superclass = None
@@ -1542,10 +1764,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1556,10 +1774,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1651,10 +1865,10 @@ class tpCPFCNPJNIF(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -1691,10 +1905,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1705,10 +1915,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1719,10 +1925,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1736,12 +1938,8 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1984,10 +2182,10 @@ class tpChaveNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xs:long'}, None),
-        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xsd:long'}, None),
+        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2024,10 +2222,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2038,10 +2232,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2052,10 +2242,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoVerificacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 8:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoVerificacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2069,10 +2255,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -2202,9 +2384,9 @@ class tpChaveRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xs:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xsd:long'}, None),
     ]
     subclass = None
     superclass = None
@@ -2238,10 +2420,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2252,10 +2430,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpSerieRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 5:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpSerieRPS' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2269,10 +2443,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2405,10 +2575,10 @@ class tpEnderecoExterior(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xs:string'}, None),
-        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xs:string'}, None),
-        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xs:string'}, None),
-        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xsd:string'}, None),
+        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xsd:string'}, None),
+        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2445,10 +2615,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -2459,10 +2625,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEndPostal, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 11:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoEndPostal' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2476,10 +2638,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpNomeCidade, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNomeCidade' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2493,10 +2651,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpEstadoProvinciaRegiao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEstadoProvinciaRegiao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2619,8 +2773,8 @@ class tpEnderecoNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xs:int'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xsd:int'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -2651,10 +2805,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2665,10 +2815,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -2762,14 +2908,14 @@ class tpEndereco(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xs:string'}, None),
-        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xs:int'}, None),
-        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xs:string'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xsd:int'}, None),
+        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xsd:int'}, None),
         MemberSpec_('EnderecoExterior', 'tpEnderecoExterior', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoExterior', 'type': 'tpEnderecoExterior'}, None),
     ]
     subclass = None
@@ -2821,10 +2967,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpTipoLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 3:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTipoLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2838,10 +2980,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2855,10 +2993,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2872,10 +3006,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2889,10 +3019,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2906,10 +3032,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2920,10 +3042,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpUF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpUF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2937,10 +3055,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3123,10 +3237,10 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     member_data_items_ = [
         MemberSpec_('endNac', 'tpEnderecoNacional', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endNac', 'type': 'tpEnderecoNacional'}, 5),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 5),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3167,10 +3281,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3184,10 +3294,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3201,10 +3307,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3218,10 +3320,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3362,12 +3460,12 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, 6),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, 6),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 6),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3409,10 +3507,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3423,10 +3517,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3440,10 +3530,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3457,10 +3543,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3474,10 +3556,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3641,14 +3719,14 @@ class tpInformacoesLote(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('DataEnvioLote', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xs:long'}, None),
-        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('DataEnvioLote', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xsd:string'}, None),
+        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xsd:long'}, None),
+        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -3666,11 +3744,7 @@ class tpInformacoesLote(GeneratedsSuper):
         self.InscricaoPrestador_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        if isinstance(DataEnvioLote, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEnvioLote, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEnvioLote
-        self.DataEnvioLote = initvalue_
+        self.DataEnvioLote = DataEnvioLote
         self.DataEnvioLote_nsprefix_ = None
         self.QtdNotasProcessadas = QtdNotasProcessadas
         self.validate_tpQuantidade(self.QtdNotasProcessadas)
@@ -3699,10 +3773,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -3713,10 +3783,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -3727,10 +3793,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpQuantidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
@@ -3741,10 +3803,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpTempoProcessamento, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpTempoProcessamento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpTempoProcessamento_patterns_, ))
@@ -3755,10 +3813,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -3831,7 +3885,7 @@ class tpInformacoesLote(GeneratedsSuper):
         if self.DataEnvioLote is not None:
             namespaceprefix_ = self.DataEnvioLote_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEnvioLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEnvioLote, input_name='DataEnvioLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEnvioLote), input_name='DataEnvioLote')), namespaceprefix_ , eol_))
         if self.QtdNotasProcessadas is not None:
             namespaceprefix_ = self.QtdNotasProcessadas_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdNotasProcessadas_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -3884,9 +3938,10 @@ class tpInformacoesLote(GeneratedsSuper):
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
         elif nodeName_ == 'DataEnvioLote':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEnvioLote = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEnvioLote')
+            value_ = self.gds_validate_string(value_, node, 'DataEnvioLote')
+            self.DataEnvioLote = value_
             self.DataEnvioLote_nsprefix_ = child_.prefix
         elif nodeName_ == 'QtdNotasProcessadas' and child_.text:
             sval_ = child_.text
@@ -3941,13 +3996,13 @@ class tpInformacoesPessoa(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'end', 'type': 'tpEnderecoIBSCBS'}, None),
-        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xs:string'}, None),
+        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3992,10 +4047,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -4006,10 +4057,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -4020,10 +4067,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4037,12 +4080,8 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4052,10 +4091,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4069,10 +4104,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4228,7 +4259,7 @@ class tpGRefNFSe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xs:string'}, None),
+        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4258,10 +4289,6 @@ class tpGRefNFSe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -4446,9 +4473,9 @@ class tpImovelObra(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xs:string'}, None),
-        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xs:string'}, 7),
-        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xs:string'}, 7),
+        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xsd:string'}, None),
+        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xsd:string'}, 7),
+        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xsd:string'}, 7),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, 7),
     ]
     subclass = None
@@ -4485,10 +4512,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpInscImobFisc, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpInscImobFisc' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4502,10 +4525,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCCIB, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCCIB_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCCIB_patterns_, ))
@@ -4516,10 +4535,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCObra, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCObra' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4690,11 +4705,11 @@ class tpDocumento(GeneratedsSuper):
         MemberSpec_('docFiscalOutro', 'tpDocFiscalOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docFiscalOutro', 'type': 'tpDocFiscalOutro'}, 8),
         MemberSpec_('docOutro', 'tpDocOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docOutro', 'type': 'tpDocOutro'}, 8),
         MemberSpec_('fornec', 'tpFornecedor', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'fornec', 'type': 'tpFornecedor'}, None),
-        MemberSpec_('dtEmiDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('dtCompDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xs:int'}, None),
-        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xs:string'}, None),
-        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('dtEmiDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtCompDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xsd:string'}, None),
+        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -4712,17 +4727,9 @@ class tpDocumento(GeneratedsSuper):
         self.docOutro_nsprefix_ = None
         self.fornec = fornec
         self.fornec_nsprefix_ = None
-        if isinstance(dtEmiDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtEmiDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtEmiDoc
-        self.dtEmiDoc = initvalue_
+        self.dtEmiDoc = dtEmiDoc
         self.dtEmiDoc_nsprefix_ = None
-        if isinstance(dtCompDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtCompDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtCompDoc
-        self.dtCompDoc = initvalue_
+        self.dtCompDoc = dtCompDoc
         self.dtCompDoc_nsprefix_ = None
         self.tpReeRepRes = tpReeRepRes
         self.validate_tpReeRepRes(self.tpReeRepRes)
@@ -4748,12 +4755,8 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpReeRepRes, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 99]
+            enumerations = ['1', '2', '3', '4', '99']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4763,10 +4766,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpXTpReeRepRes, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 150:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4780,10 +4779,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -4858,11 +4853,11 @@ class tpDocumento(GeneratedsSuper):
         if self.dtEmiDoc is not None:
             namespaceprefix_ = self.dtEmiDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtEmiDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtEmiDoc, input_name='dtEmiDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtEmiDoc), input_name='dtEmiDoc')), namespaceprefix_ , eol_))
         if self.dtCompDoc is not None:
             namespaceprefix_ = self.dtCompDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtCompDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtCompDoc, input_name='dtCompDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtCompDoc), input_name='dtCompDoc')), namespaceprefix_ , eol_))
         if self.tpReeRepRes is not None:
             namespaceprefix_ = self.tpReeRepRes_nsprefix_ + ':' if (UseCapturedNS_ and self.tpReeRepRes_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -4910,14 +4905,16 @@ class tpDocumento(GeneratedsSuper):
             self.fornec = obj_
             obj_.original_tagname_ = 'fornec'
         elif nodeName_ == 'dtEmiDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtEmiDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtEmiDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtEmiDoc')
+            self.dtEmiDoc = value_
             self.dtEmiDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtCompDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtCompDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtCompDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtCompDoc')
+            self.dtCompDoc = value_
             self.dtCompDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'tpReeRepRes' and child_.text:
             sval_ = child_.text
@@ -4954,9 +4951,9 @@ class tpDFeNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xs:int'}, None),
-        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xs:string'}, None),
-        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xs:string'}, None),
+        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4990,12 +4987,8 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpTipoChaveDFE, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 9]
+            enumerations = ['1', '2', '3', '9']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpTipoChaveDFE' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5005,10 +4998,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpXTipoChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTipoChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5022,10 +5011,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5164,9 +5149,9 @@ class tpDocFiscalOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xs:int'}, None),
-        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xs:string'}, None),
-        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xs:string'}, None),
+        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xsd:int'}, None),
+        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5200,10 +5185,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -5214,10 +5195,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5341,8 +5318,8 @@ class tpDocOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xs:string'}, None),
-        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xs:string'}, None),
+        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5373,10 +5350,6 @@ class tpDocOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5475,11 +5448,11 @@ class tpFornecedor(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5519,10 +5492,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -5533,10 +5502,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -5547,10 +5512,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5564,12 +5525,8 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5579,10 +5536,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5735,9 +5688,9 @@ class tpAtividadeEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xs:string'}, None),
-        MemberSpec_('dtIniEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xs:date'}, None),
-        MemberSpec_('dtFimEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xs:date'}, None),
+        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtIniEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtFimEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, None),
     ]
     subclass = None
@@ -5751,17 +5704,9 @@ class tpAtividadeEvento(GeneratedsSuper):
         self.xNomeEvt = xNomeEvt
         self.validate_tpXNomeEvt(self.xNomeEvt)
         self.xNomeEvt_nsprefix_ = None
-        if isinstance(dtIniEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtIniEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtIniEvt
-        self.dtIniEvt = initvalue_
+        self.dtIniEvt = dtIniEvt
         self.dtIniEvt_nsprefix_ = None
-        if isinstance(dtFimEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtFimEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtFimEvt
-        self.dtFimEvt = initvalue_
+        self.dtFimEvt = dtFimEvt
         self.dtFimEvt_nsprefix_ = None
         self.end = end
         self.end_nsprefix_ = None
@@ -5780,10 +5725,6 @@ class tpAtividadeEvento(GeneratedsSuper):
         result = True
         # Validate type tpXNomeEvt, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXNomeEvt' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5840,11 +5781,11 @@ class tpAtividadeEvento(GeneratedsSuper):
         if self.dtIniEvt is not None:
             namespaceprefix_ = self.dtIniEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtIniEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtIniEvt, input_name='dtIniEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtIniEvt), input_name='dtIniEvt')), namespaceprefix_ , eol_))
         if self.dtFimEvt is not None:
             namespaceprefix_ = self.dtFimEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFimEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFimEvt, input_name='dtFimEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtFimEvt), input_name='dtFimEvt')), namespaceprefix_ , eol_))
         if self.end is not None:
             namespaceprefix_ = self.end_nsprefix_ + ':' if (UseCapturedNS_ and self.end_nsprefix_) else ''
             self.end.export(outfile, level, namespaceprefix_, namespacedef_='', name_='end', pretty_print=pretty_print)
@@ -5871,14 +5812,16 @@ class tpAtividadeEvento(GeneratedsSuper):
             # validate type tpXNomeEvt
             self.validate_tpXNomeEvt(self.xNomeEvt)
         elif nodeName_ == 'dtIniEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtIniEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtIniEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtIniEvt')
+            self.dtIniEvt = value_
             self.dtIniEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtFimEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtFimEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtFimEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtFimEvt')
+            self.dtFimEvt = value_
             self.dtFimEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'end':
             obj_ = tpEnderecoSimplesIBSCBS.factory(parent_object_=self)
@@ -5960,13 +5903,13 @@ class tpIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xs:int'}, None),
-        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xs:int'}, None),
-        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xs:string'}, None),
-        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xs:int'}, None),
+        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xsd:int'}, None),
+        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xsd:int'}, None),
+        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xsd:int'}, None),
         MemberSpec_('gRefNFSe', 'tpGRefNFSe', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gRefNFSe', 'type': 'tpGRefNFSe'}, None),
-        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xs:int'}, None),
-        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xs:int'}, None),
+        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xsd:int'}, None),
+        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xsd:int'}, None),
         MemberSpec_('dest', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'dest', 'type': 'tpInformacoesPessoa'}, None),
         MemberSpec_('valores', 'tpValores', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'valores', 'type': 'tpValores'}, None),
         MemberSpec_('imovelobra', 'tpImovelObra', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'imovelobra', 'type': 'tpImovelObra'}, None),
@@ -6020,12 +5963,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpFinNFSe, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0]
+            enumerations = ['0']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpFinNFSe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6035,12 +5974,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6055,10 +5990,6 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCIndOp, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCIndOp_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCIndOp_patterns_, ))
@@ -6069,12 +6000,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpOper, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 5]
+            enumerations = ['1', '2', '3', '4', '5']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpOper' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6084,12 +6011,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpEnteGov, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4]
+            enumerations = ['1', '2', '3', '4']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEnteGov' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6099,12 +6022,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpIndDest, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpIndDest' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6296,7 +6215,7 @@ class tpGIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xsd:string'}, None),
         MemberSpec_('gTribRegular', 'tpGTribRegular', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gTribRegular', 'type': 'tpGTribRegular'}, None),
     ]
     subclass = None
@@ -6327,10 +6246,6 @@ class tpGIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6434,7 +6349,7 @@ class tpGTribRegular(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -6462,10 +6377,6 @@ class tpGTribRegular(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6693,45 +6604,45 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Adquirente', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Adquirente', 'type': 'tpInformacoesPessoa'}, None),
-        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xs:decimal'}, None),
+        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -6875,10 +6786,6 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -7935,67 +7842,67 @@ class tpNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, None),
-        MemberSpec_('DataEmissaoNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('DataEmissaoNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissaoRPS', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xs:date'}, None),
-        MemberSpec_('DataFatoGeradorNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xs:dateTime'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissaoRPS', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataFatoGeradorNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJPrestador', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJPrestador', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xs:string'}, None),
+        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoPrestador', 'tpEndereco', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'EnderecoPrestador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xs:string'}, None),
-        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('DataCancelamento', 'xs:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xs:long'}, None),
-        MemberSpec_('DataQuitacaoGuia', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xs:date'}, None),
-        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataQuitacaoGuia', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
         MemberSpec_('RetornoComplementarIBSCBS', 'tpRetornoComplementarIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RetornoComplementarIBSCBS', 'type': 'tpRetornoComplementarIBSCBS'}, None),
     ]
@@ -8012,11 +7919,7 @@ class tpNFe(GeneratedsSuper):
         self.Assinatura_nsprefix_ = None
         self.ChaveNFe = ChaveNFe
         self.ChaveNFe_nsprefix_ = None
-        if isinstance(DataEmissaoNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEmissaoNFe
-        self.DataEmissaoNFe = initvalue_
+        self.DataEmissaoNFe = DataEmissaoNFe
         self.DataEmissaoNFe_nsprefix_ = None
         self.NumeroLote = NumeroLote
         self.validate_tpNumero(self.NumeroLote)
@@ -8026,17 +7929,9 @@ class tpNFe(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissaoRPS, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoRPS, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissaoRPS
-        self.DataEmissaoRPS = initvalue_
+        self.DataEmissaoRPS = DataEmissaoRPS
         self.DataEmissaoRPS_nsprefix_ = None
-        if isinstance(DataFatoGeradorNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataFatoGeradorNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataFatoGeradorNFe
-        self.DataFatoGeradorNFe = initvalue_
+        self.DataFatoGeradorNFe = DataFatoGeradorNFe
         self.DataFatoGeradorNFe_nsprefix_ = None
         self.CPFCNPJPrestador = CPFCNPJPrestador
         self.CPFCNPJPrestador_nsprefix_ = None
@@ -8051,11 +7946,7 @@ class tpNFe(GeneratedsSuper):
         self.StatusNFe = StatusNFe
         self.validate_tpStatusNFe(self.StatusNFe)
         self.StatusNFe_nsprefix_ = None
-        if isinstance(DataCancelamento, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataCancelamento
-        self.DataCancelamento = initvalue_
+        self.DataCancelamento = DataCancelamento
         self.DataCancelamento_nsprefix_ = None
         self.TributacaoNFe = TributacaoNFe
         self.validate_tpTributacaoNFe(self.TributacaoNFe)
@@ -8066,11 +7957,7 @@ class tpNFe(GeneratedsSuper):
         self.NumeroGuia = NumeroGuia
         self.validate_tpNumero(self.NumeroGuia)
         self.NumeroGuia_nsprefix_ = None
-        if isinstance(DataQuitacaoGuia, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataQuitacaoGuia, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataQuitacaoGuia
-        self.DataQuitacaoGuia = initvalue_
+        self.DataQuitacaoGuia = DataQuitacaoGuia
         self.DataQuitacaoGuia_nsprefix_ = None
         self.ValorServicos = ValorServicos
         self.validate_tpValor(self.ValorServicos)
@@ -8220,10 +8107,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -8234,10 +8117,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -8249,10 +8128,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8266,10 +8141,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8283,10 +8154,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -8298,10 +8165,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8315,10 +8178,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpOpcaoSimples, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['0', '1', '2', '3', '4', '6']
             if value not in enumerations:
@@ -8330,10 +8189,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -8352,10 +8207,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -8366,10 +8217,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -8383,10 +8230,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -8397,10 +8240,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -8411,10 +8250,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8428,10 +8263,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -8445,10 +8276,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8462,10 +8289,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -8476,12 +8299,8 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8496,10 +8315,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -8510,10 +8325,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -8524,10 +8335,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -8643,7 +8450,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoNFe is not None:
             namespaceprefix_ = self.DataEmissaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEmissaoNFe, input_name='DataEmissaoNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoNFe), input_name='DataEmissaoNFe')), namespaceprefix_ , eol_))
         if self.NumeroLote is not None:
             namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8658,11 +8465,11 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoRPS is not None:
             namespaceprefix_ = self.DataEmissaoRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissaoRPS, input_name='DataEmissaoRPS'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoRPS), input_name='DataEmissaoRPS')), namespaceprefix_ , eol_))
         if self.DataFatoGeradorNFe is not None:
             namespaceprefix_ = self.DataFatoGeradorNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataFatoGeradorNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataFatoGeradorNFe, input_name='DataFatoGeradorNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataFatoGeradorNFe), input_name='DataFatoGeradorNFe')), namespaceprefix_ , eol_))
         if self.CPFCNPJPrestador is not None:
             namespaceprefix_ = self.CPFCNPJPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJPrestador_nsprefix_) else ''
             self.CPFCNPJPrestador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJPrestador', pretty_print=pretty_print)
@@ -8684,7 +8491,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataCancelamento is not None:
             namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataCancelamento), input_name='DataCancelamento')), namespaceprefix_ , eol_))
         if self.TributacaoNFe is not None:
             namespaceprefix_ = self.TributacaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.TributacaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8700,7 +8507,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataQuitacaoGuia is not None:
             namespaceprefix_ = self.DataQuitacaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacaoGuia_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacaoGuia, input_name='DataQuitacaoGuia'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataQuitacaoGuia), input_name='DataQuitacaoGuia')), namespaceprefix_ , eol_))
         if self.ValorServicos is not None:
             namespaceprefix_ = self.ValorServicos_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorServicos_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8748,7 +8555,7 @@ class tpNFe(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -8909,9 +8716,10 @@ class tpNFe(GeneratedsSuper):
             self.ChaveNFe = obj_
             obj_.original_tagname_ = 'ChaveNFe'
         elif nodeName_ == 'DataEmissaoNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEmissaoNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoNFe')
+            self.DataEmissaoNFe = value_
             self.DataEmissaoNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'NumeroLote' and child_.text:
             sval_ = child_.text
@@ -8935,14 +8743,16 @@ class tpNFe(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissaoRPS':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissaoRPS = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoRPS')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoRPS')
+            self.DataEmissaoRPS = value_
             self.DataEmissaoRPS_nsprefix_ = child_.prefix
         elif nodeName_ == 'DataFatoGeradorNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataFatoGeradorNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataFatoGeradorNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataFatoGeradorNFe')
+            self.DataFatoGeradorNFe = value_
             self.DataFatoGeradorNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJPrestador':
             obj_ = tpCPFCNPJ.factory(parent_object_=self)
@@ -8979,9 +8789,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpStatusNFe
             self.validate_tpStatusNFe(self.StatusNFe)
         elif nodeName_ == 'DataCancelamento':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataCancelamento = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataCancelamento')
+            value_ = self.gds_validate_string(value_, node, 'DataCancelamento')
+            self.DataCancelamento = value_
             self.DataCancelamento_nsprefix_ = child_.prefix
         elif nodeName_ == 'TributacaoNFe':
             value_ = child_.text
@@ -9008,9 +8819,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpNumero
             self.validate_tpNumero(self.NumeroGuia)
         elif nodeName_ == 'DataQuitacaoGuia':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataQuitacaoGuia = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataQuitacaoGuia')
+            value_ = self.gds_validate_string(value_, node, 'DataQuitacaoGuia')
+            self.DataQuitacaoGuia = value_
             self.DataQuitacaoGuia_nsprefix_ = child_.prefix
         elif nodeName_ == 'ValorServicos' and child_.text:
             sval_ = child_.text
@@ -9101,10 +8913,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpValor
             self.validate_tpValor(self.ValorCredito)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -9426,8 +9238,7 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipalTomador esteja pre
-    enchido.
+    ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9657,52 +9468,52 @@ class tpRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissao', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xs:date'}, None),
-        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissao', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
     ]
     subclass = None
@@ -9721,11 +9532,7 @@ class tpRPS(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissao, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissao
-        self.DataEmissao = initvalue_
+        self.DataEmissao = DataEmissao
         self.DataEmissao_nsprefix_ = None
         self.StatusRPS = StatusRPS
         self.validate_tpStatusNFe(self.StatusRPS)
@@ -9870,10 +9677,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -9885,10 +9688,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -9900,10 +9699,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -9917,10 +9712,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -9939,10 +9730,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -9953,10 +9740,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -9970,10 +9753,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -9984,10 +9763,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -9998,10 +9773,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10015,10 +9786,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10032,10 +9799,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10049,10 +9812,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -10066,10 +9825,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10083,10 +9838,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -10097,10 +9848,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -10111,12 +9858,8 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10131,10 +9874,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -10145,10 +9884,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -10159,10 +9894,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -10266,7 +9997,7 @@ class tpRPS(GeneratedsSuper):
         if self.DataEmissao is not None:
             namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissao), input_name='DataEmissao')), namespaceprefix_ , eol_))
         if self.StatusRPS is not None:
             namespaceprefix_ = self.StatusRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.StatusRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -10310,7 +10041,7 @@ class tpRPS(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -10476,9 +10207,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissao':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissao = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissao')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissao')
+            self.DataEmissao = value_
             self.DataEmissao_nsprefix_ = child_.prefix
         elif nodeName_ == 'StatusRPS':
             value_ = child_.text
@@ -10561,10 +10293,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpAliquota
             self.validate_tpAliquota(self.AliquotaServicos)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -10811,7 +10543,7 @@ class tpRPS(GeneratedsSuper):
 class SignatureType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('SignedInfo', 'SignedInfoType', 0, 0, {'name': 'SignedInfo', 'type': 'SignedInfoType'}, None),
         MemberSpec_('SignatureValue', 'SignatureValueType', 0, 0, {'name': 'SignatureValue', 'type': 'SignatureValueType'}, None),
         MemberSpec_('KeyInfo', 'KeyInfoType', 0, 0, {'name': 'KeyInfo', 'type': 'KeyInfoType'}, None),
@@ -10878,7 +10610,7 @@ class SignatureType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -10931,8 +10663,8 @@ class SignatureType(GeneratedsSuper):
 class SignatureValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
-        MemberSpec_('valueOf_', 'xs:base64Binary', 0),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('valueOf_', 'base64Binary', 0),
     ]
     subclass = None
     superclass = None
@@ -10986,7 +10718,7 @@ class SignatureValueType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureValueType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureValueType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -11014,7 +10746,7 @@ class SignatureValueType(GeneratedsSuper):
 class SignedInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('CanonicalizationMethod', 'CanonicalizationMethodType', 0, 0, {'name': 'CanonicalizationMethod', 'type': 'CanonicalizationMethodType'}, None),
         MemberSpec_('SignatureMethod', 'SignatureMethodType', 0, 0, {'name': 'SignatureMethod', 'type': 'SignatureMethodType'}, None),
         MemberSpec_('Reference', 'ReferenceType', 1, 0, {'maxOccurs': 'unbounded', 'name': 'Reference', 'type': 'ReferenceType'}, None),
@@ -11084,7 +10816,7 @@ class SignedInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignedInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignedInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11137,12 +10869,12 @@ class SignedInfoType(GeneratedsSuper):
 class ReferenceType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('URI', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'URI'}),
         MemberSpec_('Type', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'Type'}),
         MemberSpec_('Transforms', 'TransformsType', 0, 0, {'name': 'Transforms', 'type': 'TransformsType'}, None),
         MemberSpec_('DigestMethod', 'DigestMethodType', 0, 0, {'name': 'DigestMethod', 'type': 'DigestMethodType'}, None),
-        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -11217,13 +10949,13 @@ class ReferenceType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='ReferenceType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
         if self.URI is not None and 'URI' not in already_processed:
             already_processed.add('URI')
-            outfile.write(' URI=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.URI), input_name='URI')), ))
+            outfile.write(' URI=%s' % (quote_attrib(self.URI), ))
         if self.Type is not None and 'Type' not in already_processed:
             already_processed.add('Type')
-            outfile.write(' Type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Type), input_name='Type')), ))
+            outfile.write(' Type=%s' % (quote_attrib(self.Type), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='ReferenceType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11386,7 +11118,7 @@ class TransformType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Algorithm', 'xs:anyURI', 0, 0, {'use': 'required', 'name': 'Algorithm'}),
-        MemberSpec_('XPath', 'xs:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xs:string'}, None),
+        MemberSpec_('XPath', 'xsd:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11402,7 +11134,7 @@ class TransformType(GeneratedsSuper):
             self.XPath = []
         else:
             self.XPath = XPath
-        self.XPath_nsprefix_ = None
+        self.XPath_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11447,7 +11179,7 @@ class TransformType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='TransformType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='TransformType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11486,7 +11218,7 @@ class TransformType(GeneratedsSuper):
 class KeyInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('X509Data', 'X509DataType', 0, 0, {'name': 'X509Data', 'type': 'X509DataType'}, None),
     ]
     subclass = None
@@ -11545,7 +11277,7 @@ class KeyInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='KeyInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='KeyInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11670,7 +11402,7 @@ class KeyValueType(GeneratedsSuper):
 class X509DataType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('X509Certificate', 'xs:base64Binary', 0, 0, {'name': 'X509Certificate', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('X509Certificate', 'xsd:string', 0, 0, {'name': 'X509Certificate', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11681,7 +11413,7 @@ class X509DataType(GeneratedsSuper):
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
         self.X509Certificate = X509Certificate
-        self.X509Certificate_nsprefix_ = None
+        self.X509Certificate_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11733,7 +11465,7 @@ class X509DataType(GeneratedsSuper):
         if self.X509Certificate is not None:
             namespaceprefix_ = self.X509Certificate_nsprefix_ + ':' if (UseCapturedNS_ and self.X509Certificate_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_format_base64(self.X509Certificate, input_name='X509Certificate'), namespaceprefix_ , eol_))
+            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.X509Certificate), input_name='X509Certificate')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11749,137 +11481,123 @@ class X509DataType(GeneratedsSuper):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if nodeName_ == 'X509Certificate':
-            sval_ = child_.text
-            if sval_ is not None:
-                try:
-                    bval_ = base64.b64decode(sval_)
-                except (TypeError, ValueError) as exp:
-                    raise_parse_error(child_, 'requires base64 encoded string: %s' % exp)
-                bval_ = self.gds_validate_base64(bval_, node, 'X509Certificate')
-            else:
-                bval_ = None
-            self.X509Certificate = bval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'X509Certificate')
+            value_ = self.gds_validate_string(value_, node, 'X509Certificate')
+            self.X509Certificate = value_
             self.X509Certificate_nsprefix_ = child_.prefix
 # end class X509DataType
 
 
-class CabecalhoType(GeneratedsSuper):
-    """CabecalhoType -- Cabe
+class tpEventoAsync(GeneratedsSuper):
+    """Codigo -- C
+    ó
+    digo do evento.
+    Descricao -- Descri
     ç
-    alho do pedido de cancelamento de lote.
-    Versao -- Informe a Vers
     ã
-    o do Schema XML utilizado.
-    CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-    NumeroLote -- Informe o n
-    ú
-    mero do Lote a ser cancelado.
+    o do evento.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
-        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, NumeroLote=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Codigo=None, Descricao=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
-        self.Versao = _cast(None, Versao)
-        self.Versao_nsprefix_ = None
-        self.CPFCNPJRemetente = CPFCNPJRemetente
-        self.CPFCNPJRemetente_nsprefix_ = None
-        self.NumeroLote = NumeroLote
-        self.validate_tpNumero(self.NumeroLote)
-        self.NumeroLote_nsprefix_ = None
+        self.Codigo = Codigo
+        self.validate_tpCodigoEvento(self.Codigo)
+        self.Codigo_nsprefix_ = None
+        self.Descricao = Descricao
+        self.validate_tpDescricaoEvento(self.Descricao)
+        self.Descricao_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, CabecalhoType)
+                CurrentSubclassModule_, tpEventoAsync)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if CabecalhoType.subclass:
-            return CabecalhoType.subclass(*args_, **kwargs_)
+        if tpEventoAsync.subclass:
+            return tpEventoAsync.subclass(*args_, **kwargs_)
         else:
-            return CabecalhoType(*args_, **kwargs_)
+            return tpEventoAsync(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def validate_tpNumero(self, value):
+    def validate_tpCodigoEvento(self, value):
         result = True
-        # Validate type tpNumero, a restriction on xs:long.
+        # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
-                    self.validate_tpNumero_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                    self.validate_tpCodigoEvento_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
                 result = False
         return result
-    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
-    def validate_tpVersao(self, value):
-        # Validate type tipos:tpVersao, a restriction on xs:long.
+    validate_tpCodigoEvento_patterns_ = [['^([0-9]{3,4})$']]
+    def validate_tpDescricaoEvento(self, value):
+        result = True
+        # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
+            if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
-            if not self.gds_validate_simple_patterns(
-                    self.validate_tpVersao_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpVersao_patterns_, ))
-    validate_tpVersao_patterns_ = [['^([0-9]{1,3})$']]
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
     def has__content(self):
         if (
-            self.CPFCNPJRemetente is not None or
-            self.NumeroLote is not None
+            self.Codigo is not None or
+            self.Descricao is not None
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('CabecalhoType')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpEventoAsync')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'CabecalhoType':
+        if self.original_tagname_ is not None and name_ == 'tpEventoAsync':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='CabecalhoType')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpEventoAsync')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='CabecalhoType', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpEventoAsync', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CabecalhoType'):
-        if self.Versao is not None and 'Versao' not in already_processed:
-            already_processed.add('Versao')
-            outfile.write(' Versao="%s"' % self.gds_format_integer(self.Versao, input_name='Versao'))
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', fromsubclass_=False, pretty_print=True):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpEventoAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.CPFCNPJRemetente is not None:
-            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
-            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
-        if self.NumeroLote is not None:
-            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+        if self.Codigo is not None:
+            namespaceprefix_ = self.Codigo_nsprefix_ + ':' if (UseCapturedNS_ and self.Codigo_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sCodigo>%s</%sCodigo>%s' % (namespaceprefix_ , self.gds_format_integer(self.Codigo, input_name='Codigo'), namespaceprefix_ , eol_))
+        if self.Descricao is not None:
+            namespaceprefix_ = self.Descricao_nsprefix_ + ':' if (UseCapturedNS_ and self.Descricao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDescricao>%s</%sDescricao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Descricao), input_name='Descricao')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11892,26 +11610,386 @@ class CabecalhoType(GeneratedsSuper):
             self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
         return self
     def _buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('Versao', node)
-        if value is not None and 'Versao' not in already_processed:
-            already_processed.add('Versao')
-            self.Versao = self.gds_parse_integer(value, node, 'Versao')
-            self.validate_tpVersao(self.Versao)    # validate type tpVersao
+        pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'CPFCNPJRemetente':
-            obj_ = tpCPFCNPJ.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.CPFCNPJRemetente = obj_
-            obj_.original_tagname_ = 'CPFCNPJRemetente'
-        elif nodeName_ == 'NumeroLote' and child_.text:
+        if nodeName_ == 'Codigo' and child_.text:
             sval_ = child_.text
-            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
-            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
-            self.NumeroLote = ival_
-            self.NumeroLote_nsprefix_ = child_.prefix
-            # validate type tpNumero
-            self.validate_tpNumero(self.NumeroLote)
-# end class CabecalhoType
+            ival_ = self.gds_parse_integer(sval_, node, 'Codigo')
+            ival_ = self.gds_validate_integer(ival_, node, 'Codigo')
+            self.Codigo = ival_
+            self.Codigo_nsprefix_ = child_.prefix
+            # validate type tpCodigoEvento
+            self.validate_tpCodigoEvento(self.Codigo)
+        elif nodeName_ == 'Descricao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Descricao')
+            value_ = self.gds_validate_string(value_, node, 'Descricao')
+            self.Descricao = value_
+            self.Descricao_nsprefix_ = child_.prefix
+            # validate type tpDescricaoEvento
+            self.validate_tpDescricaoEvento(self.Descricao)
+# end class tpEventoAsync
+
+
+class tpInformacoesLoteAsync(GeneratedsSuper):
+    """tpInformacoesLoteAsync -- Informa
+    ç
+    õ
+    es do lote processado.
+    NumeroProtocolo -- N
+    ú
+    mero do protocolo do lote.
+    DataRecebimento -- Data/hora de envio do lote.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesLoteAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesLoteAsync.subclass:
+            return tpInformacoesLoteAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesLoteAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesLoteAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesLoteAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesLoteAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesLoteAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesLoteAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesLoteAsync
+
+
+class tpInformacoesGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesGuiaAsync.subclass:
+            return tpInformacoesGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesGuiaAsync
+
+
+class SituacaoType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('nome', 'async:tpSituacaoLote', 0, 1, {'use': 'optional', 'name': 'nome'}),
+        MemberSpec_('valueOf_', 'xsd:int', 0),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, nome=None, valueOf_=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.nome = _cast(None, nome)
+        self.nome_nsprefix_ = None
+        self.valueOf_ = valueOf_
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, SituacaoType)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if SituacaoType.subclass:
+            return SituacaoType.subclass(*args_, **kwargs_)
+        else:
+            return SituacaoType(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpSituacaoLote(self, value):
+        # Validate type async:tpSituacaoLote, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = ['enviado', 'invalidado', 'verificado', 'processado']
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpSituacaoLote' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+    def has__content(self):
+        if (
+            (1 if type(self.valueOf_) in [int,float] else self.valueOf_)
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SituacaoType', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('SituacaoType')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'SituacaoType':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='SituacaoType')
+        outfile.write('>')
+        self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_, pretty_print=pretty_print)
+        outfile.write(self.convert_unicode(self.valueOf_))
+        outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SituacaoType'):
+        if self.nome is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            outfile.write(' nome=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.nome), input_name='nome')), ))
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SituacaoType', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        self.valueOf_ = get_all_text_(node)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('nome', node)
+        if value is not None and 'nome' not in already_processed:
+            already_processed.add('nome')
+            self.nome = value
+            self.validate_tpSituacaoLote(self.nome)    # validate type tpSituacaoLote
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        pass
+# end class SituacaoType
 
 
 class CanonicalizationMethodType(GeneratedsSuper):
@@ -11972,7 +12050,7 @@ class CanonicalizationMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CanonicalizationMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CanonicalizationMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12054,7 +12132,7 @@ class SignatureMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SignatureMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SignatureMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12136,7 +12214,7 @@ class DigestMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DigestMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DigestMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12163,8 +12241,8 @@ class DigestMethodType(GeneratedsSuper):
 class RSAKeyValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xs:base64Binary'}, None),
-        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xsd:base64Binary'}, None),
+        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -12342,8 +12420,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoLote'
+        rootClass = PedidoConsultaSituacaoLote
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12374,8 +12452,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoLote'
+        rootClass = PedidoConsultaSituacaoLote
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12420,8 +12498,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoLote'
+        rootClass = PedidoConsultaSituacaoLote
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12448,8 +12526,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoConsultaSituacaoLote'
+        rootClass = PedidoConsultaSituacaoLote
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12457,8 +12535,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoCancelamentoLote import *\n\n')
-        sys.stdout.write('import PedidoCancelamentoLote as model_\n\n')
+        sys.stdout.write('#from ConsultaSituacaoLoteAsync import *\n\n')
+        sys.stdout.write('import ConsultaSituacaoLoteAsync as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12773,6 +12851,30 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                                 'CT'),
                                                ('tpRPS',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
+                                                'CT'),
+                                               ('tpNumeroProtocoloAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpIncidencia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoLote',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEmissaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEventoAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesLoteAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesGuiaAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
                                                 'CT')],
  'http://www.w3.org/2000/09/xmldsig#': [('CryptoBinary',
                                          'schemas/nfse/xmldsig-core-schema_v02.xsd',
@@ -12809,18 +12911,19 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                          'CT')]}
 
 __all__ = [
-    "CabecalhoType",
     "CanonicalizationMethodType",
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoCancelamentoLote",
+    "PedidoConsultaSituacaoLote",
     "RSAKeyValueType",
     "ReferenceType",
+    "RetornoConsultaSituacaoLote",
     "SignatureMethodType",
     "SignatureType",
     "SignatureValueType",
     "SignedInfoType",
+    "SituacaoType",
     "TransformType",
     "TransformsType",
     "X509DataType",
@@ -12840,6 +12943,7 @@ __all__ = [
     "tpEnderecoNacional",
     "tpEnderecoSimplesIBSCBS",
     "tpEvento",
+    "tpEventoAsync",
     "tpFornecedor",
     "tpGIBSCBS",
     "tpGRefNFSe",
@@ -12847,7 +12951,9 @@ __all__ = [
     "tpGrupoReeRepRes",
     "tpIBSCBS",
     "tpImovelObra",
+    "tpInformacoesGuiaAsync",
     "tpInformacoesLote",
+    "tpInformacoesLoteAsync",
     "tpInformacoesPessoa",
     "tpNFe",
     "tpRPS",

--- a/nfselib/paulistana/v03/EmissaoGuiaAsync.py
+++ b/nfselib/paulistana/v03/EmissaoGuiaAsync.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoCancelamentoLote.py')
+#   ('-o', 'nfselib/paulistana/v03/EmissaoGuiaAsync.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   schemas/nfse/EmissaoGuiaAsync_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoLote.py" schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/EmissaoGuiaAsync.py" schemas/nfse/EmissaoGuiaAsync_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1008,6 +1008,17 @@ def _cast(typ, value):
 #
 # Start enum classes
 #
+class tpEmissaoGuia(str, Enum):
+    _1='1' # Guia de NFS-e emitidas
+    _2='2' # Guia de NFS-e recebidas (exceto rejeitadas)
+    _3='3' # Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)
+    _4='4' # Guia de NFS-e recebidas aceitas
+    _5='5' # Guia de NFS-e recebidas sem manifestação do tomador
+    _6='6' # Guia de NFS-e recebidas rejeitadas
+    _7='7' # Guia de NFTS emitidas
+    _8='8' # Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)
+
+
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
     
@@ -1128,7 +1139,8 @@ class tpReeRepRes(str, Enum):
     ê
     ncia de propaganda e publicidade por valores pagos relativos a servi
     ç
-    os de produ
+    os de p
+    rodu
     ç
     ã
     o externa por conta e ordem de terceiro.
@@ -1160,6 +1172,42 @@ class tpReferencia(str, Enum):
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
+
+
+class tpSituacaoGuia(str, Enum):
+    """tpSituacaoGuia -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es da emiss
+    ã
+    o de guia ass
+    í
+    ncrona.
+    
+    """
+    SOLICITADA='solicitada' # Emissao solicitada (0).
+    INVALIDADA='invalidada' # Emissao invalidada (1).
+    VERIFICADA='verificada' # Emissao verificada (2).
+    PROCESSADA='processada' # Emissao processada (3).
+
+
+class tpSituacaoLote(str, Enum):
+    """tpSituacaoLote -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es do lote ass
+    í
+    ncrono.
+    
+    """
+    ENVIADO='enviado' # Lote enviado (0).
+    INVALIDADO='invalidado' # Lote invalidado (1).
+    VERIFICADO='verificado' # Lote verificado (2).
+    PROCESSADO='processado' # Lote processado (3).
 
 
 class tpStatusNFe(str, Enum):
@@ -1211,27 +1259,222 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoCancelamentoLote(GeneratedsSuper):
-    """PedidoCancelamentoLote -- Schema utilizado para PEDIDO de cancelamento de lote.
-    Este Schema XML
-    é
-    utilizado pelos prestadores de servi
-    ç
-    os cancelarem as NFS-e geradas a partir de um lote de RPS.
-    Cabecalho -- Cabe
-    ç
-    alho do pedido de cancelamento de lote.
-    Signature -- Assinatura digital do CNPJ emissor dos RPS.
-    
-    """
+class PedidoEmissaoGuiaAsync(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
+        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('TipoEmissaoGuia', ['tpEmissaoGuia', 'xsd:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoEmissaoGuia', 'type': 'xsd:int'}, None),
+        MemberSpec_('Incidencia', ['tpIncidencia', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Incidencia', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataPagamento', 'xsd:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataPagamento', 'type': 'xsd:date'}, None),
         MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, CPFCNPJRemetente=None, InscricaoPrestador=None, TipoEmissaoGuia=None, Incidencia=None, DataPagamento=None, Signature=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.CPFCNPJRemetente = CPFCNPJRemetente
+        self.CPFCNPJRemetente_nsprefix_ = None
+        self.InscricaoPrestador = InscricaoPrestador
+        self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        self.InscricaoPrestador_nsprefix_ = None
+        self.TipoEmissaoGuia = TipoEmissaoGuia
+        self.validate_tpEmissaoGuia(self.TipoEmissaoGuia)
+        self.TipoEmissaoGuia_nsprefix_ = None
+        self.Incidencia = Incidencia
+        self.validate_tpIncidencia(self.Incidencia)
+        self.Incidencia_nsprefix_ = None
+        if isinstance(DataPagamento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataPagamento, '%Y-%m-%d').date()
+        else:
+            initvalue_ = DataPagamento
+        self.DataPagamento = initvalue_
+        self.DataPagamento_nsprefix_ = None
+        self.Signature = Signature
+        self.Signature_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, PedidoEmissaoGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if PedidoEmissaoGuiaAsync.subclass:
+            return PedidoEmissaoGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return PedidoEmissaoGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpInscricaoMunicipal(self, value):
+        result = True
+        # Validate type tpInscricaoMunicipal, a restriction on xs:long.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpInscricaoMunicipal_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
+                result = False
+        return result
+    validate_tpInscricaoMunicipal_patterns_ = [['^([0-9]{1,12})$']]
+    def validate_tpEmissaoGuia(self, value):
+        result = True
+        # Validate type tpEmissaoGuia, a restriction on xsd:int.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, int):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
+                return False
+            value = value
+            enumerations = [1, 2, 3, 4, 5, 6, 7, 8]
+            if value not in enumerations:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEmissaoGuia' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def validate_tpIncidencia(self, value):
+        result = True
+        # Validate type tpIncidencia, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpIncidencia_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpIncidencia_patterns_, ))
+                result = False
+        return result
+    validate_tpIncidencia_patterns_ = [['^(^((19|20)\\d\\d)-(0?[1-9]|1[012])$)$']]
+    def has__content(self):
+        if (
+            self.CPFCNPJRemetente is not None or
+            self.InscricaoPrestador is not None or
+            self.TipoEmissaoGuia is not None or
+            self.Incidencia is not None or
+            self.DataPagamento is not None or
+            self.Signature is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoEmissaoGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoEmissaoGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'PedidoEmissaoGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoEmissaoGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoEmissaoGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoEmissaoGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoEmissaoGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.CPFCNPJRemetente is not None:
+            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
+            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
+        if self.InscricaoPrestador is not None:
+            namespaceprefix_ = self.InscricaoPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.InscricaoPrestador_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sInscricaoPrestador>%s</%sInscricaoPrestador>%s' % (namespaceprefix_ , self.gds_format_integer(self.InscricaoPrestador, input_name='InscricaoPrestador'), namespaceprefix_ , eol_))
+        if self.TipoEmissaoGuia is not None:
+            namespaceprefix_ = self.TipoEmissaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.TipoEmissaoGuia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sTipoEmissaoGuia>%s</%sTipoEmissaoGuia>%s' % (namespaceprefix_ , self.gds_format_integer(self.TipoEmissaoGuia, input_name='TipoEmissaoGuia'), namespaceprefix_ , eol_))
+        if self.Incidencia is not None:
+            namespaceprefix_ = self.Incidencia_nsprefix_ + ':' if (UseCapturedNS_ and self.Incidencia_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sIncidencia>%s</%sIncidencia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Incidencia), input_name='Incidencia')), namespaceprefix_ , eol_))
+        if self.DataPagamento is not None:
+            namespaceprefix_ = self.DataPagamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataPagamento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataPagamento>%s</%sDataPagamento>%s' % (namespaceprefix_ , self.gds_format_date(self.DataPagamento, input_name='DataPagamento'), namespaceprefix_ , eol_))
+        if self.Signature is not None:
+            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
+            self.Signature.export(outfile, level, namespaceprefix_='sig:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'CPFCNPJRemetente':
+            obj_ = tpCPFCNPJ.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.CPFCNPJRemetente = obj_
+            obj_.original_tagname_ = 'CPFCNPJRemetente'
+        elif nodeName_ == 'InscricaoPrestador' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'InscricaoPrestador')
+            ival_ = self.gds_validate_integer(ival_, node, 'InscricaoPrestador')
+            self.InscricaoPrestador = ival_
+            self.InscricaoPrestador_nsprefix_ = child_.prefix
+            # validate type tpInscricaoMunicipal
+            self.validate_tpInscricaoMunicipal(self.InscricaoPrestador)
+        elif nodeName_ == 'TipoEmissaoGuia' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'TipoEmissaoGuia')
+            ival_ = self.gds_validate_integer(ival_, node, 'TipoEmissaoGuia')
+            self.TipoEmissaoGuia = ival_
+            self.TipoEmissaoGuia_nsprefix_ = child_.prefix
+            # validate type tpEmissaoGuia
+            self.validate_tpEmissaoGuia(self.TipoEmissaoGuia)
+        elif nodeName_ == 'Incidencia':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Incidencia')
+            value_ = self.gds_validate_string(value_, node, 'Incidencia')
+            self.Incidencia = value_
+            self.Incidencia_nsprefix_ = child_.prefix
+            # validate type tpIncidencia
+            self.validate_tpIncidencia(self.Incidencia)
+        elif nodeName_ == 'DataPagamento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.DataPagamento = dval_
+            self.DataPagamento_nsprefix_ = child_.prefix
+        elif nodeName_ == 'Signature':
+            obj_ = SignatureType.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.Signature = obj_
+            obj_.original_tagname_ = 'Signature'
+# end class PedidoEmissaoGuiaAsync
+
+
+class RetornoEmissaoGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
+        MemberSpec_('Erro', 'tpEventoAsync', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'Erro', 'type': 'tpEventoAsync'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Cabecalho=None, Erro=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1239,53 +1482,56 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Cabecalho = Cabecalho
         self.Cabecalho_nsprefix_ = None
-        self.Signature = Signature
-        self.Signature_nsprefix_ = None
+        if Erro is None:
+            self.Erro = []
+        else:
+            self.Erro = Erro
+        self.Erro_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoCancelamentoLote)
+                CurrentSubclassModule_, RetornoEmissaoGuiaAsync)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoCancelamentoLote.subclass:
-            return PedidoCancelamentoLote.subclass(*args_, **kwargs_)
+        if RetornoEmissaoGuiaAsync.subclass:
+            return RetornoEmissaoGuiaAsync.subclass(*args_, **kwargs_)
         else:
-            return PedidoCancelamentoLote(*args_, **kwargs_)
+            return RetornoEmissaoGuiaAsync(*args_, **kwargs_)
     factory = staticmethod(factory)
     def has__content(self):
         if (
             self.Cabecalho is not None or
-            self.Signature is not None
+            self.Erro
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoCancelamentoLote')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoEmissaoGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RetornoEmissaoGuiaAsync')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoCancelamentoLote':
+        if self.original_tagname_ is not None and name_ == 'RetornoEmissaoGuiaAsync':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoCancelamentoLote')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RetornoEmissaoGuiaAsync')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoCancelamentoLote', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RetornoEmissaoGuiaAsync', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoCancelamentoLote'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RetornoEmissaoGuiaAsync'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoEmissaoGuiaAsync', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
@@ -1293,9 +1539,9 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         if self.Cabecalho is not None:
             namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
             self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
-        if self.Signature is not None:
-            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
-            self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+        for Erro_ in self.Erro:
+            namespaceprefix_ = self.Erro_nsprefix_ + ':' if (UseCapturedNS_ and self.Erro_nsprefix_) else ''
+            Erro_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Erro', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -1315,12 +1561,12 @@ class PedidoCancelamentoLote(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.Cabecalho = obj_
             obj_.original_tagname_ = 'Cabecalho'
-        elif nodeName_ == 'Signature':
-            obj_ = SignatureType.factory(parent_object_=self)
+        elif nodeName_ == 'Erro':
+            obj_ = tpEventoAsync.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Signature = obj_
-            obj_.original_tagname_ = 'Signature'
-# end class PedidoCancelamentoLote
+            self.Erro.append(obj_)
+            obj_.original_tagname_ = 'Erro'
+# end class RetornoEmissaoGuiaAsync
 
 
 class tpEvento(GeneratedsSuper):
@@ -1342,8 +1588,8 @@ class tpEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xs:short'}, None),
-        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xs:string'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 3),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 3),
     ]
@@ -1380,10 +1626,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoEvento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
@@ -1394,10 +1636,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1510,8 +1748,8 @@ class tpCPFCNPJ(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, 4),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, 4),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, 4),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, 4),
     ]
     subclass = None
     superclass = None
@@ -1542,10 +1780,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1556,10 +1790,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1651,10 +1881,10 @@ class tpCPFCNPJNIF(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -1691,10 +1921,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1705,10 +1931,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1719,10 +1941,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1736,12 +1954,8 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1984,10 +2198,10 @@ class tpChaveNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xs:long'}, None),
-        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xsd:long'}, None),
+        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2024,10 +2238,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2038,10 +2248,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2052,10 +2258,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoVerificacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 8:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoVerificacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2069,10 +2271,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -2202,9 +2400,9 @@ class tpChaveRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xs:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xsd:long'}, None),
     ]
     subclass = None
     superclass = None
@@ -2238,10 +2436,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2252,10 +2446,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpSerieRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 5:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpSerieRPS' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2269,10 +2459,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2405,10 +2591,10 @@ class tpEnderecoExterior(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xs:string'}, None),
-        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xs:string'}, None),
-        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xs:string'}, None),
-        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xsd:string'}, None),
+        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xsd:string'}, None),
+        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2445,10 +2631,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -2459,10 +2641,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEndPostal, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 11:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoEndPostal' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2476,10 +2654,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpNomeCidade, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNomeCidade' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2493,10 +2667,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpEstadoProvinciaRegiao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEstadoProvinciaRegiao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2619,8 +2789,8 @@ class tpEnderecoNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xs:int'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xsd:int'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -2651,10 +2821,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2665,10 +2831,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -2762,14 +2924,14 @@ class tpEndereco(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xs:string'}, None),
-        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xs:int'}, None),
-        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xs:string'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xsd:int'}, None),
+        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xsd:int'}, None),
         MemberSpec_('EnderecoExterior', 'tpEnderecoExterior', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoExterior', 'type': 'tpEnderecoExterior'}, None),
     ]
     subclass = None
@@ -2821,10 +2983,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpTipoLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 3:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTipoLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2838,10 +2996,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2855,10 +3009,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2872,10 +3022,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2889,10 +3035,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2906,10 +3048,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2920,10 +3058,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpUF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpUF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2937,10 +3071,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3123,10 +3253,10 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     member_data_items_ = [
         MemberSpec_('endNac', 'tpEnderecoNacional', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endNac', 'type': 'tpEnderecoNacional'}, 5),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 5),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3167,10 +3297,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3184,10 +3310,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3201,10 +3323,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3218,10 +3336,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3362,12 +3476,12 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, 6),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, 6),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 6),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3409,10 +3523,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3423,10 +3533,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3440,10 +3546,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3457,10 +3559,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3474,10 +3572,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3641,14 +3735,14 @@ class tpInformacoesLote(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('DataEnvioLote', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xs:long'}, None),
-        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('DataEnvioLote', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xsd:string'}, None),
+        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xsd:long'}, None),
+        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -3666,11 +3760,7 @@ class tpInformacoesLote(GeneratedsSuper):
         self.InscricaoPrestador_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        if isinstance(DataEnvioLote, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEnvioLote, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEnvioLote
-        self.DataEnvioLote = initvalue_
+        self.DataEnvioLote = DataEnvioLote
         self.DataEnvioLote_nsprefix_ = None
         self.QtdNotasProcessadas = QtdNotasProcessadas
         self.validate_tpQuantidade(self.QtdNotasProcessadas)
@@ -3699,10 +3789,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -3713,10 +3799,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -3727,10 +3809,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpQuantidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
@@ -3741,10 +3819,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpTempoProcessamento, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpTempoProcessamento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpTempoProcessamento_patterns_, ))
@@ -3755,10 +3829,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -3831,7 +3901,7 @@ class tpInformacoesLote(GeneratedsSuper):
         if self.DataEnvioLote is not None:
             namespaceprefix_ = self.DataEnvioLote_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEnvioLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEnvioLote, input_name='DataEnvioLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEnvioLote), input_name='DataEnvioLote')), namespaceprefix_ , eol_))
         if self.QtdNotasProcessadas is not None:
             namespaceprefix_ = self.QtdNotasProcessadas_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdNotasProcessadas_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -3884,9 +3954,10 @@ class tpInformacoesLote(GeneratedsSuper):
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
         elif nodeName_ == 'DataEnvioLote':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEnvioLote = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEnvioLote')
+            value_ = self.gds_validate_string(value_, node, 'DataEnvioLote')
+            self.DataEnvioLote = value_
             self.DataEnvioLote_nsprefix_ = child_.prefix
         elif nodeName_ == 'QtdNotasProcessadas' and child_.text:
             sval_ = child_.text
@@ -3941,13 +4012,13 @@ class tpInformacoesPessoa(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'end', 'type': 'tpEnderecoIBSCBS'}, None),
-        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xs:string'}, None),
+        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3992,10 +4063,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -4006,10 +4073,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -4020,10 +4083,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4037,12 +4096,8 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4052,10 +4107,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4069,10 +4120,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4228,7 +4275,7 @@ class tpGRefNFSe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xs:string'}, None),
+        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4258,10 +4305,6 @@ class tpGRefNFSe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -4446,9 +4489,9 @@ class tpImovelObra(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xs:string'}, None),
-        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xs:string'}, 7),
-        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xs:string'}, 7),
+        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xsd:string'}, None),
+        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xsd:string'}, 7),
+        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xsd:string'}, 7),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, 7),
     ]
     subclass = None
@@ -4485,10 +4528,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpInscImobFisc, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpInscImobFisc' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4502,10 +4541,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCCIB, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCCIB_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCCIB_patterns_, ))
@@ -4516,10 +4551,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCObra, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCObra' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4690,11 +4721,11 @@ class tpDocumento(GeneratedsSuper):
         MemberSpec_('docFiscalOutro', 'tpDocFiscalOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docFiscalOutro', 'type': 'tpDocFiscalOutro'}, 8),
         MemberSpec_('docOutro', 'tpDocOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docOutro', 'type': 'tpDocOutro'}, 8),
         MemberSpec_('fornec', 'tpFornecedor', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'fornec', 'type': 'tpFornecedor'}, None),
-        MemberSpec_('dtEmiDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('dtCompDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xs:int'}, None),
-        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xs:string'}, None),
-        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('dtEmiDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtCompDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xsd:string'}, None),
+        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -4712,17 +4743,9 @@ class tpDocumento(GeneratedsSuper):
         self.docOutro_nsprefix_ = None
         self.fornec = fornec
         self.fornec_nsprefix_ = None
-        if isinstance(dtEmiDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtEmiDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtEmiDoc
-        self.dtEmiDoc = initvalue_
+        self.dtEmiDoc = dtEmiDoc
         self.dtEmiDoc_nsprefix_ = None
-        if isinstance(dtCompDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtCompDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtCompDoc
-        self.dtCompDoc = initvalue_
+        self.dtCompDoc = dtCompDoc
         self.dtCompDoc_nsprefix_ = None
         self.tpReeRepRes = tpReeRepRes
         self.validate_tpReeRepRes(self.tpReeRepRes)
@@ -4748,12 +4771,8 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpReeRepRes, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 99]
+            enumerations = ['1', '2', '3', '4', '99']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4763,10 +4782,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpXTpReeRepRes, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 150:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4780,10 +4795,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -4858,11 +4869,11 @@ class tpDocumento(GeneratedsSuper):
         if self.dtEmiDoc is not None:
             namespaceprefix_ = self.dtEmiDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtEmiDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtEmiDoc, input_name='dtEmiDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtEmiDoc), input_name='dtEmiDoc')), namespaceprefix_ , eol_))
         if self.dtCompDoc is not None:
             namespaceprefix_ = self.dtCompDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtCompDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtCompDoc, input_name='dtCompDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtCompDoc), input_name='dtCompDoc')), namespaceprefix_ , eol_))
         if self.tpReeRepRes is not None:
             namespaceprefix_ = self.tpReeRepRes_nsprefix_ + ':' if (UseCapturedNS_ and self.tpReeRepRes_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -4910,14 +4921,16 @@ class tpDocumento(GeneratedsSuper):
             self.fornec = obj_
             obj_.original_tagname_ = 'fornec'
         elif nodeName_ == 'dtEmiDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtEmiDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtEmiDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtEmiDoc')
+            self.dtEmiDoc = value_
             self.dtEmiDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtCompDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtCompDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtCompDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtCompDoc')
+            self.dtCompDoc = value_
             self.dtCompDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'tpReeRepRes' and child_.text:
             sval_ = child_.text
@@ -4954,9 +4967,9 @@ class tpDFeNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xs:int'}, None),
-        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xs:string'}, None),
-        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xs:string'}, None),
+        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4990,12 +5003,8 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpTipoChaveDFE, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 9]
+            enumerations = ['1', '2', '3', '9']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpTipoChaveDFE' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5005,10 +5014,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpXTipoChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTipoChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5022,10 +5027,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5164,9 +5165,9 @@ class tpDocFiscalOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xs:int'}, None),
-        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xs:string'}, None),
-        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xs:string'}, None),
+        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xsd:int'}, None),
+        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5200,10 +5201,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -5214,10 +5211,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5341,8 +5334,8 @@ class tpDocOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xs:string'}, None),
-        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xs:string'}, None),
+        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5373,10 +5366,6 @@ class tpDocOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5475,11 +5464,11 @@ class tpFornecedor(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5519,10 +5508,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -5533,10 +5518,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -5547,10 +5528,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5564,12 +5541,8 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5579,10 +5552,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5735,9 +5704,9 @@ class tpAtividadeEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xs:string'}, None),
-        MemberSpec_('dtIniEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xs:date'}, None),
-        MemberSpec_('dtFimEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xs:date'}, None),
+        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtIniEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtFimEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, None),
     ]
     subclass = None
@@ -5751,17 +5720,9 @@ class tpAtividadeEvento(GeneratedsSuper):
         self.xNomeEvt = xNomeEvt
         self.validate_tpXNomeEvt(self.xNomeEvt)
         self.xNomeEvt_nsprefix_ = None
-        if isinstance(dtIniEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtIniEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtIniEvt
-        self.dtIniEvt = initvalue_
+        self.dtIniEvt = dtIniEvt
         self.dtIniEvt_nsprefix_ = None
-        if isinstance(dtFimEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtFimEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtFimEvt
-        self.dtFimEvt = initvalue_
+        self.dtFimEvt = dtFimEvt
         self.dtFimEvt_nsprefix_ = None
         self.end = end
         self.end_nsprefix_ = None
@@ -5780,10 +5741,6 @@ class tpAtividadeEvento(GeneratedsSuper):
         result = True
         # Validate type tpXNomeEvt, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXNomeEvt' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5840,11 +5797,11 @@ class tpAtividadeEvento(GeneratedsSuper):
         if self.dtIniEvt is not None:
             namespaceprefix_ = self.dtIniEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtIniEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtIniEvt, input_name='dtIniEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtIniEvt), input_name='dtIniEvt')), namespaceprefix_ , eol_))
         if self.dtFimEvt is not None:
             namespaceprefix_ = self.dtFimEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFimEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFimEvt, input_name='dtFimEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtFimEvt), input_name='dtFimEvt')), namespaceprefix_ , eol_))
         if self.end is not None:
             namespaceprefix_ = self.end_nsprefix_ + ':' if (UseCapturedNS_ and self.end_nsprefix_) else ''
             self.end.export(outfile, level, namespaceprefix_, namespacedef_='', name_='end', pretty_print=pretty_print)
@@ -5871,14 +5828,16 @@ class tpAtividadeEvento(GeneratedsSuper):
             # validate type tpXNomeEvt
             self.validate_tpXNomeEvt(self.xNomeEvt)
         elif nodeName_ == 'dtIniEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtIniEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtIniEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtIniEvt')
+            self.dtIniEvt = value_
             self.dtIniEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtFimEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtFimEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtFimEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtFimEvt')
+            self.dtFimEvt = value_
             self.dtFimEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'end':
             obj_ = tpEnderecoSimplesIBSCBS.factory(parent_object_=self)
@@ -5960,13 +5919,13 @@ class tpIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xs:int'}, None),
-        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xs:int'}, None),
-        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xs:string'}, None),
-        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xs:int'}, None),
+        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xsd:int'}, None),
+        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xsd:int'}, None),
+        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xsd:int'}, None),
         MemberSpec_('gRefNFSe', 'tpGRefNFSe', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gRefNFSe', 'type': 'tpGRefNFSe'}, None),
-        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xs:int'}, None),
-        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xs:int'}, None),
+        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xsd:int'}, None),
+        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xsd:int'}, None),
         MemberSpec_('dest', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'dest', 'type': 'tpInformacoesPessoa'}, None),
         MemberSpec_('valores', 'tpValores', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'valores', 'type': 'tpValores'}, None),
         MemberSpec_('imovelobra', 'tpImovelObra', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'imovelobra', 'type': 'tpImovelObra'}, None),
@@ -6020,12 +5979,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpFinNFSe, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0]
+            enumerations = ['0']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpFinNFSe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6035,12 +5990,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6055,10 +6006,6 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCIndOp, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCIndOp_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCIndOp_patterns_, ))
@@ -6069,12 +6016,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpOper, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 5]
+            enumerations = ['1', '2', '3', '4', '5']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpOper' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6084,12 +6027,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpEnteGov, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4]
+            enumerations = ['1', '2', '3', '4']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEnteGov' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6099,12 +6038,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpIndDest, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpIndDest' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6296,7 +6231,7 @@ class tpGIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xsd:string'}, None),
         MemberSpec_('gTribRegular', 'tpGTribRegular', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gTribRegular', 'type': 'tpGTribRegular'}, None),
     ]
     subclass = None
@@ -6327,10 +6262,6 @@ class tpGIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6434,7 +6365,7 @@ class tpGTribRegular(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -6462,10 +6393,6 @@ class tpGTribRegular(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6693,45 +6620,45 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Adquirente', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Adquirente', 'type': 'tpInformacoesPessoa'}, None),
-        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xs:decimal'}, None),
+        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -6875,10 +6802,6 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -7935,67 +7858,67 @@ class tpNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, None),
-        MemberSpec_('DataEmissaoNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('DataEmissaoNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissaoRPS', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xs:date'}, None),
-        MemberSpec_('DataFatoGeradorNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xs:dateTime'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissaoRPS', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataFatoGeradorNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJPrestador', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJPrestador', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xs:string'}, None),
+        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoPrestador', 'tpEndereco', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'EnderecoPrestador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xs:string'}, None),
-        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('DataCancelamento', 'xs:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xs:long'}, None),
-        MemberSpec_('DataQuitacaoGuia', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xs:date'}, None),
-        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataQuitacaoGuia', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
         MemberSpec_('RetornoComplementarIBSCBS', 'tpRetornoComplementarIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RetornoComplementarIBSCBS', 'type': 'tpRetornoComplementarIBSCBS'}, None),
     ]
@@ -8012,11 +7935,7 @@ class tpNFe(GeneratedsSuper):
         self.Assinatura_nsprefix_ = None
         self.ChaveNFe = ChaveNFe
         self.ChaveNFe_nsprefix_ = None
-        if isinstance(DataEmissaoNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEmissaoNFe
-        self.DataEmissaoNFe = initvalue_
+        self.DataEmissaoNFe = DataEmissaoNFe
         self.DataEmissaoNFe_nsprefix_ = None
         self.NumeroLote = NumeroLote
         self.validate_tpNumero(self.NumeroLote)
@@ -8026,17 +7945,9 @@ class tpNFe(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissaoRPS, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoRPS, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissaoRPS
-        self.DataEmissaoRPS = initvalue_
+        self.DataEmissaoRPS = DataEmissaoRPS
         self.DataEmissaoRPS_nsprefix_ = None
-        if isinstance(DataFatoGeradorNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataFatoGeradorNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataFatoGeradorNFe
-        self.DataFatoGeradorNFe = initvalue_
+        self.DataFatoGeradorNFe = DataFatoGeradorNFe
         self.DataFatoGeradorNFe_nsprefix_ = None
         self.CPFCNPJPrestador = CPFCNPJPrestador
         self.CPFCNPJPrestador_nsprefix_ = None
@@ -8051,11 +7962,7 @@ class tpNFe(GeneratedsSuper):
         self.StatusNFe = StatusNFe
         self.validate_tpStatusNFe(self.StatusNFe)
         self.StatusNFe_nsprefix_ = None
-        if isinstance(DataCancelamento, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataCancelamento
-        self.DataCancelamento = initvalue_
+        self.DataCancelamento = DataCancelamento
         self.DataCancelamento_nsprefix_ = None
         self.TributacaoNFe = TributacaoNFe
         self.validate_tpTributacaoNFe(self.TributacaoNFe)
@@ -8066,11 +7973,7 @@ class tpNFe(GeneratedsSuper):
         self.NumeroGuia = NumeroGuia
         self.validate_tpNumero(self.NumeroGuia)
         self.NumeroGuia_nsprefix_ = None
-        if isinstance(DataQuitacaoGuia, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataQuitacaoGuia, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataQuitacaoGuia
-        self.DataQuitacaoGuia = initvalue_
+        self.DataQuitacaoGuia = DataQuitacaoGuia
         self.DataQuitacaoGuia_nsprefix_ = None
         self.ValorServicos = ValorServicos
         self.validate_tpValor(self.ValorServicos)
@@ -8220,10 +8123,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -8234,10 +8133,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -8249,10 +8144,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8266,10 +8157,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8283,10 +8170,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -8298,10 +8181,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8315,10 +8194,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpOpcaoSimples, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['0', '1', '2', '3', '4', '6']
             if value not in enumerations:
@@ -8330,10 +8205,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -8352,10 +8223,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -8366,10 +8233,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -8383,10 +8246,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -8397,10 +8256,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -8411,10 +8266,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8428,10 +8279,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -8445,10 +8292,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8462,10 +8305,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -8476,12 +8315,8 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8496,10 +8331,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -8510,10 +8341,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -8524,10 +8351,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -8643,7 +8466,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoNFe is not None:
             namespaceprefix_ = self.DataEmissaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEmissaoNFe, input_name='DataEmissaoNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoNFe), input_name='DataEmissaoNFe')), namespaceprefix_ , eol_))
         if self.NumeroLote is not None:
             namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8658,11 +8481,11 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoRPS is not None:
             namespaceprefix_ = self.DataEmissaoRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissaoRPS, input_name='DataEmissaoRPS'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoRPS), input_name='DataEmissaoRPS')), namespaceprefix_ , eol_))
         if self.DataFatoGeradorNFe is not None:
             namespaceprefix_ = self.DataFatoGeradorNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataFatoGeradorNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataFatoGeradorNFe, input_name='DataFatoGeradorNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataFatoGeradorNFe), input_name='DataFatoGeradorNFe')), namespaceprefix_ , eol_))
         if self.CPFCNPJPrestador is not None:
             namespaceprefix_ = self.CPFCNPJPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJPrestador_nsprefix_) else ''
             self.CPFCNPJPrestador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJPrestador', pretty_print=pretty_print)
@@ -8684,7 +8507,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataCancelamento is not None:
             namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataCancelamento), input_name='DataCancelamento')), namespaceprefix_ , eol_))
         if self.TributacaoNFe is not None:
             namespaceprefix_ = self.TributacaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.TributacaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8700,7 +8523,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataQuitacaoGuia is not None:
             namespaceprefix_ = self.DataQuitacaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacaoGuia_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacaoGuia, input_name='DataQuitacaoGuia'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataQuitacaoGuia), input_name='DataQuitacaoGuia')), namespaceprefix_ , eol_))
         if self.ValorServicos is not None:
             namespaceprefix_ = self.ValorServicos_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorServicos_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8748,7 +8571,7 @@ class tpNFe(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -8909,9 +8732,10 @@ class tpNFe(GeneratedsSuper):
             self.ChaveNFe = obj_
             obj_.original_tagname_ = 'ChaveNFe'
         elif nodeName_ == 'DataEmissaoNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEmissaoNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoNFe')
+            self.DataEmissaoNFe = value_
             self.DataEmissaoNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'NumeroLote' and child_.text:
             sval_ = child_.text
@@ -8935,14 +8759,16 @@ class tpNFe(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissaoRPS':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissaoRPS = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoRPS')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoRPS')
+            self.DataEmissaoRPS = value_
             self.DataEmissaoRPS_nsprefix_ = child_.prefix
         elif nodeName_ == 'DataFatoGeradorNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataFatoGeradorNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataFatoGeradorNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataFatoGeradorNFe')
+            self.DataFatoGeradorNFe = value_
             self.DataFatoGeradorNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJPrestador':
             obj_ = tpCPFCNPJ.factory(parent_object_=self)
@@ -8979,9 +8805,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpStatusNFe
             self.validate_tpStatusNFe(self.StatusNFe)
         elif nodeName_ == 'DataCancelamento':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataCancelamento = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataCancelamento')
+            value_ = self.gds_validate_string(value_, node, 'DataCancelamento')
+            self.DataCancelamento = value_
             self.DataCancelamento_nsprefix_ = child_.prefix
         elif nodeName_ == 'TributacaoNFe':
             value_ = child_.text
@@ -9008,9 +8835,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpNumero
             self.validate_tpNumero(self.NumeroGuia)
         elif nodeName_ == 'DataQuitacaoGuia':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataQuitacaoGuia = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataQuitacaoGuia')
+            value_ = self.gds_validate_string(value_, node, 'DataQuitacaoGuia')
+            self.DataQuitacaoGuia = value_
             self.DataQuitacaoGuia_nsprefix_ = child_.prefix
         elif nodeName_ == 'ValorServicos' and child_.text:
             sval_ = child_.text
@@ -9101,10 +8929,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpValor
             self.validate_tpValor(self.ValorCredito)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -9426,8 +9254,7 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipalTomador esteja pre
-    enchido.
+    ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9657,52 +9484,52 @@ class tpRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissao', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xs:date'}, None),
-        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissao', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
     ]
     subclass = None
@@ -9721,11 +9548,7 @@ class tpRPS(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissao, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissao
-        self.DataEmissao = initvalue_
+        self.DataEmissao = DataEmissao
         self.DataEmissao_nsprefix_ = None
         self.StatusRPS = StatusRPS
         self.validate_tpStatusNFe(self.StatusRPS)
@@ -9870,10 +9693,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -9885,10 +9704,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -9900,10 +9715,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -9917,10 +9728,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -9939,10 +9746,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -9953,10 +9756,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -9970,10 +9769,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -9984,10 +9779,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -9998,10 +9789,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10015,10 +9802,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10032,10 +9815,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10049,10 +9828,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -10066,10 +9841,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10083,10 +9854,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -10097,10 +9864,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -10111,12 +9874,8 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10131,10 +9890,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -10145,10 +9900,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -10159,10 +9910,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -10266,7 +10013,7 @@ class tpRPS(GeneratedsSuper):
         if self.DataEmissao is not None:
             namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissao), input_name='DataEmissao')), namespaceprefix_ , eol_))
         if self.StatusRPS is not None:
             namespaceprefix_ = self.StatusRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.StatusRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -10310,7 +10057,7 @@ class tpRPS(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -10476,9 +10223,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissao':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissao = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissao')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissao')
+            self.DataEmissao = value_
             self.DataEmissao_nsprefix_ = child_.prefix
         elif nodeName_ == 'StatusRPS':
             value_ = child_.text
@@ -10561,10 +10309,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpAliquota
             self.validate_tpAliquota(self.AliquotaServicos)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -10811,7 +10559,7 @@ class tpRPS(GeneratedsSuper):
 class SignatureType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('SignedInfo', 'SignedInfoType', 0, 0, {'name': 'SignedInfo', 'type': 'SignedInfoType'}, None),
         MemberSpec_('SignatureValue', 'SignatureValueType', 0, 0, {'name': 'SignatureValue', 'type': 'SignatureValueType'}, None),
         MemberSpec_('KeyInfo', 'KeyInfoType', 0, 0, {'name': 'KeyInfo', 'type': 'KeyInfoType'}, None),
@@ -10878,7 +10626,7 @@ class SignatureType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -10931,8 +10679,8 @@ class SignatureType(GeneratedsSuper):
 class SignatureValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
-        MemberSpec_('valueOf_', 'xs:base64Binary', 0),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('valueOf_', 'base64Binary', 0),
     ]
     subclass = None
     superclass = None
@@ -10986,7 +10734,7 @@ class SignatureValueType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureValueType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureValueType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -11014,7 +10762,7 @@ class SignatureValueType(GeneratedsSuper):
 class SignedInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('CanonicalizationMethod', 'CanonicalizationMethodType', 0, 0, {'name': 'CanonicalizationMethod', 'type': 'CanonicalizationMethodType'}, None),
         MemberSpec_('SignatureMethod', 'SignatureMethodType', 0, 0, {'name': 'SignatureMethod', 'type': 'SignatureMethodType'}, None),
         MemberSpec_('Reference', 'ReferenceType', 1, 0, {'maxOccurs': 'unbounded', 'name': 'Reference', 'type': 'ReferenceType'}, None),
@@ -11084,7 +10832,7 @@ class SignedInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignedInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignedInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11137,12 +10885,12 @@ class SignedInfoType(GeneratedsSuper):
 class ReferenceType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('URI', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'URI'}),
         MemberSpec_('Type', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'Type'}),
         MemberSpec_('Transforms', 'TransformsType', 0, 0, {'name': 'Transforms', 'type': 'TransformsType'}, None),
         MemberSpec_('DigestMethod', 'DigestMethodType', 0, 0, {'name': 'DigestMethod', 'type': 'DigestMethodType'}, None),
-        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -11217,13 +10965,13 @@ class ReferenceType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='ReferenceType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
         if self.URI is not None and 'URI' not in already_processed:
             already_processed.add('URI')
-            outfile.write(' URI=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.URI), input_name='URI')), ))
+            outfile.write(' URI=%s' % (quote_attrib(self.URI), ))
         if self.Type is not None and 'Type' not in already_processed:
             already_processed.add('Type')
-            outfile.write(' Type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Type), input_name='Type')), ))
+            outfile.write(' Type=%s' % (quote_attrib(self.Type), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='ReferenceType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11386,7 +11134,7 @@ class TransformType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Algorithm', 'xs:anyURI', 0, 0, {'use': 'required', 'name': 'Algorithm'}),
-        MemberSpec_('XPath', 'xs:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xs:string'}, None),
+        MemberSpec_('XPath', 'xsd:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11402,7 +11150,7 @@ class TransformType(GeneratedsSuper):
             self.XPath = []
         else:
             self.XPath = XPath
-        self.XPath_nsprefix_ = None
+        self.XPath_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11447,7 +11195,7 @@ class TransformType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='TransformType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='TransformType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11486,7 +11234,7 @@ class TransformType(GeneratedsSuper):
 class KeyInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('X509Data', 'X509DataType', 0, 0, {'name': 'X509Data', 'type': 'X509DataType'}, None),
     ]
     subclass = None
@@ -11545,7 +11293,7 @@ class KeyInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='KeyInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='KeyInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11670,7 +11418,7 @@ class KeyValueType(GeneratedsSuper):
 class X509DataType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('X509Certificate', 'xs:base64Binary', 0, 0, {'name': 'X509Certificate', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('X509Certificate', 'xsd:string', 0, 0, {'name': 'X509Certificate', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11681,7 +11429,7 @@ class X509DataType(GeneratedsSuper):
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
         self.X509Certificate = X509Certificate
-        self.X509Certificate_nsprefix_ = None
+        self.X509Certificate_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11733,7 +11481,7 @@ class X509DataType(GeneratedsSuper):
         if self.X509Certificate is not None:
             namespaceprefix_ = self.X509Certificate_nsprefix_ + ':' if (UseCapturedNS_ and self.X509Certificate_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_format_base64(self.X509Certificate, input_name='X509Certificate'), namespaceprefix_ , eol_))
+            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.X509Certificate), input_name='X509Certificate')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11749,42 +11497,430 @@ class X509DataType(GeneratedsSuper):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if nodeName_ == 'X509Certificate':
-            sval_ = child_.text
-            if sval_ is not None:
-                try:
-                    bval_ = base64.b64decode(sval_)
-                except (TypeError, ValueError) as exp:
-                    raise_parse_error(child_, 'requires base64 encoded string: %s' % exp)
-                bval_ = self.gds_validate_base64(bval_, node, 'X509Certificate')
-            else:
-                bval_ = None
-            self.X509Certificate = bval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'X509Certificate')
+            value_ = self.gds_validate_string(value_, node, 'X509Certificate')
+            self.X509Certificate = value_
             self.X509Certificate_nsprefix_ = child_.prefix
 # end class X509DataType
 
 
-class CabecalhoType(GeneratedsSuper):
-    """CabecalhoType -- Cabe
+class tpEventoAsync(GeneratedsSuper):
+    """Codigo -- C
+    ó
+    digo do evento.
+    Descricao -- Descri
     ç
-    alho do pedido de cancelamento de lote.
-    Versao -- Informe a Vers
     ã
-    o do Schema XML utilizado.
-    CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-    NumeroLote -- Informe o n
-    ú
-    mero do Lote a ser cancelado.
+    o do evento.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
-        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, NumeroLote=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Codigo=None, Descricao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.Codigo = Codigo
+        self.validate_tpCodigoEvento(self.Codigo)
+        self.Codigo_nsprefix_ = None
+        self.Descricao = Descricao
+        self.validate_tpDescricaoEvento(self.Descricao)
+        self.Descricao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpEventoAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpEventoAsync.subclass:
+            return tpEventoAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpEventoAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpCodigoEvento(self, value):
+        result = True
+        # Validate type tpCodigoEvento, a restriction on xs:short.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpCodigoEvento_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
+                result = False
+        return result
+    validate_tpCodigoEvento_patterns_ = [['^([0-9]{3,4})$']]
+    def validate_tpDescricaoEvento(self, value):
+        result = True
+        # Validate type tpDescricaoEvento, a restriction on xs:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if len(value) > 300:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.Codigo is not None or
+            self.Descricao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpEventoAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpEventoAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpEventoAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpEventoAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpEventoAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Codigo is not None:
+            namespaceprefix_ = self.Codigo_nsprefix_ + ':' if (UseCapturedNS_ and self.Codigo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sCodigo>%s</%sCodigo>%s' % (namespaceprefix_ , self.gds_format_integer(self.Codigo, input_name='Codigo'), namespaceprefix_ , eol_))
+        if self.Descricao is not None:
+            namespaceprefix_ = self.Descricao_nsprefix_ + ':' if (UseCapturedNS_ and self.Descricao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDescricao>%s</%sDescricao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Descricao), input_name='Descricao')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Codigo' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Codigo')
+            ival_ = self.gds_validate_integer(ival_, node, 'Codigo')
+            self.Codigo = ival_
+            self.Codigo_nsprefix_ = child_.prefix
+            # validate type tpCodigoEvento
+            self.validate_tpCodigoEvento(self.Codigo)
+        elif nodeName_ == 'Descricao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Descricao')
+            value_ = self.gds_validate_string(value_, node, 'Descricao')
+            self.Descricao = value_
+            self.Descricao_nsprefix_ = child_.prefix
+            # validate type tpDescricaoEvento
+            self.validate_tpDescricaoEvento(self.Descricao)
+# end class tpEventoAsync
+
+
+class tpInformacoesLoteAsync(GeneratedsSuper):
+    """tpInformacoesLoteAsync -- Informa
+    ç
+    õ
+    es do lote processado.
+    NumeroProtocolo -- N
+    ú
+    mero do protocolo do lote.
+    DataRecebimento -- Data/hora de envio do lote.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesLoteAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesLoteAsync.subclass:
+            return tpInformacoesLoteAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesLoteAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesLoteAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesLoteAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesLoteAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesLoteAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesLoteAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesLoteAsync
+
+
+class tpInformacoesGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesGuiaAsync.subclass:
+            return tpInformacoesGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesGuiaAsync
+
+
+class CabecalhoType(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
+        MemberSpec_('Sucesso', ['tpSucesso', 'xs:boolean'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Sucesso', 'type': 'xsd:boolean'}, None),
+        MemberSpec_('InformacoesGuia', 'tpInformacoesGuiaAsync', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InformacoesGuia', 'type': 'tpInformacoesGuiaAsync'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Versao=None, Sucesso=None, InformacoesGuia=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -11792,11 +11928,11 @@ class CabecalhoType(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Versao = _cast(None, Versao)
         self.Versao_nsprefix_ = None
-        self.CPFCNPJRemetente = CPFCNPJRemetente
-        self.CPFCNPJRemetente_nsprefix_ = None
-        self.NumeroLote = NumeroLote
-        self.validate_tpNumero(self.NumeroLote)
-        self.NumeroLote_nsprefix_ = None
+        self.Sucesso = Sucesso
+        self.validate_tpSucesso(self.Sucesso)
+        self.Sucesso_nsprefix_ = None
+        self.InformacoesGuia = InformacoesGuia
+        self.InformacoesGuia_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11808,35 +11944,23 @@ class CabecalhoType(GeneratedsSuper):
         else:
             return CabecalhoType(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def validate_tpNumero(self, value):
+    def validate_tpSucesso(self, value):
         result = True
-        # Validate type tpNumero, a restriction on xs:long.
+        # Validate type tpSucesso, a restriction on xs:boolean.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
-            if not self.gds_validate_simple_patterns(
-                    self.validate_tpNumero_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
-                result = False
+            pass
         return result
-    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
     def validate_tpVersao(self, value):
         # Validate type tipos:tpVersao, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpVersao_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpVersao_patterns_, ))
     validate_tpVersao_patterns_ = [['^([0-9]{1,3})$']]
     def has__content(self):
         if (
-            self.CPFCNPJRemetente is not None or
-            self.NumeroLote is not None
+            self.Sucesso is not None or
+            self.InformacoesGuia is not None
         ):
             return True
         else:
@@ -11867,19 +11991,19 @@ class CabecalhoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CabecalhoType'):
         if self.Versao is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            outfile.write(' Versao="%s"' % self.gds_format_integer(self.Versao, input_name='Versao'))
+            outfile.write(' Versao=%s' % (quote_attrib(self.Versao), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.CPFCNPJRemetente is not None:
-            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
-            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
-        if self.NumeroLote is not None:
-            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+        if self.Sucesso is not None:
+            namespaceprefix_ = self.Sucesso_nsprefix_ + ':' if (UseCapturedNS_ and self.Sucesso_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sSucesso>%s</%sSucesso>%s' % (namespaceprefix_ , self.gds_format_boolean(self.Sucesso, input_name='Sucesso'), namespaceprefix_ , eol_))
+        if self.InformacoesGuia is not None:
+            namespaceprefix_ = self.InformacoesGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.InformacoesGuia_nsprefix_) else ''
+            self.InformacoesGuia.export(outfile, level, namespaceprefix_, namespacedef_='', name_='InformacoesGuia', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11895,22 +12019,22 @@ class CabecalhoType(GeneratedsSuper):
         value = find_attr_value_('Versao', node)
         if value is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            self.Versao = self.gds_parse_integer(value, node, 'Versao')
+            self.Versao = value
             self.validate_tpVersao(self.Versao)    # validate type tpVersao
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'CPFCNPJRemetente':
-            obj_ = tpCPFCNPJ.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.CPFCNPJRemetente = obj_
-            obj_.original_tagname_ = 'CPFCNPJRemetente'
-        elif nodeName_ == 'NumeroLote' and child_.text:
+        if nodeName_ == 'Sucesso':
             sval_ = child_.text
-            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
-            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
-            self.NumeroLote = ival_
-            self.NumeroLote_nsprefix_ = child_.prefix
-            # validate type tpNumero
-            self.validate_tpNumero(self.NumeroLote)
+            ival_ = self.gds_parse_boolean(sval_, node, 'Sucesso')
+            ival_ = self.gds_validate_boolean(ival_, node, 'Sucesso')
+            self.Sucesso = ival_
+            self.Sucesso_nsprefix_ = child_.prefix
+            # validate type tpSucesso
+            self.validate_tpSucesso(self.Sucesso)
+        elif nodeName_ == 'InformacoesGuia':
+            obj_ = tpInformacoesGuiaAsync.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.InformacoesGuia = obj_
+            obj_.original_tagname_ = 'InformacoesGuia'
 # end class CabecalhoType
 
 
@@ -11972,7 +12096,7 @@ class CanonicalizationMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CanonicalizationMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CanonicalizationMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12054,7 +12178,7 @@ class SignatureMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SignatureMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SignatureMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12136,7 +12260,7 @@ class DigestMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DigestMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DigestMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12163,8 +12287,8 @@ class DigestMethodType(GeneratedsSuper):
 class RSAKeyValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xs:base64Binary'}, None),
-        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xsd:base64Binary'}, None),
+        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -12342,8 +12466,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEmissaoGuiaAsync'
+        rootClass = PedidoEmissaoGuiaAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12374,8 +12498,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEmissaoGuiaAsync'
+        rootClass = PedidoEmissaoGuiaAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12420,8 +12544,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEmissaoGuiaAsync'
+        rootClass = PedidoEmissaoGuiaAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12430,7 +12554,7 @@ def parseString(inString, silence=False, print_warnings=True):
         sys.stdout.write('<?xml version="1.0" ?>\n')
         rootObj.export(
             sys.stdout, 0, name_=rootTag,
-            namespacedef_='')
+            namespacedef_='xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"')
     if print_warnings and len(gds_collector.get_messages()) > 0:
         separator = ('-' * 50) + '\n'
         sys.stderr.write(separator)
@@ -12448,8 +12572,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEmissaoGuiaAsync'
+        rootClass = PedidoEmissaoGuiaAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12457,8 +12581,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoCancelamentoLote import *\n\n')
-        sys.stdout.write('import PedidoCancelamentoLote as model_\n\n')
+        sys.stdout.write('#from EmissaoGuiaAsync import *\n\n')
+        sys.stdout.write('import EmissaoGuiaAsync as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12773,6 +12897,30 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                                 'CT'),
                                                ('tpRPS',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
+                                                'CT'),
+                                               ('tpNumeroProtocoloAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpIncidencia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoLote',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEmissaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEventoAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesLoteAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesGuiaAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
                                                 'CT')],
  'http://www.w3.org/2000/09/xmldsig#': [('CryptoBinary',
                                          'schemas/nfse/xmldsig-core-schema_v02.xsd',
@@ -12814,9 +12962,10 @@ __all__ = [
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoCancelamentoLote",
+    "PedidoEmissaoGuiaAsync",
     "RSAKeyValueType",
     "ReferenceType",
+    "RetornoEmissaoGuiaAsync",
     "SignatureMethodType",
     "SignatureType",
     "SignatureValueType",
@@ -12840,6 +12989,7 @@ __all__ = [
     "tpEnderecoNacional",
     "tpEnderecoSimplesIBSCBS",
     "tpEvento",
+    "tpEventoAsync",
     "tpFornecedor",
     "tpGIBSCBS",
     "tpGRefNFSe",
@@ -12847,7 +12997,9 @@ __all__ = [
     "tpGrupoReeRepRes",
     "tpIBSCBS",
     "tpImovelObra",
+    "tpInformacoesGuiaAsync",
     "tpInformacoesLote",
+    "tpInformacoesLoteAsync",
     "tpInformacoesPessoa",
     "tpNFe",
     "tpRPS",

--- a/nfselib/paulistana/v03/PedidoCancelamentoNFe.py
+++ b/nfselib/paulistana/v03/PedidoCancelamentoNFe.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoCancelamentoNFe_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoNFe.py" schemas/nfse/PedidoCancelamentoNFe_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoNFe.py" schemas/nfse/PedidoCancelamentoNFe_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1225,7 +1225,7 @@ class PedidoCancelamentoNFe(GeneratedsSuper):
     á
     conter a Chave de uma NFS-e e sua respectiva assinatura de cancelamento.
     Signature -- Assinatura digital do CNPJ emissor das NFS-e
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1356,7 +1356,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1523,9 +1523,9 @@ class tpEvento(GeneratedsSuper):
 
 
 class tpCPFCNPJ(GeneratedsSuper):
-    """tpCPFCNPJ -- Tipo que repre
-    senta um CPF/CNPJ.
-
+    """tpCPFCNPJ -- Tipo que represent
+    a um CPF/CNPJ.
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1666,7 +1666,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1877,7 +1877,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1999,7 +1999,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2217,7 +2217,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2420,7 +2420,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2634,7 +2634,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2777,7 +2777,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3136,7 +3136,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3377,7 +3377,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3656,7 +3656,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3956,7 +3956,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4243,7 +4243,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4367,7 +4367,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4461,7 +4461,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4701,7 +4701,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4969,7 +4969,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5179,7 +5179,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5356,7 +5356,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5490,7 +5490,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5750,7 +5750,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5975,7 +5975,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6311,7 +6311,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6449,7 +6449,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6707,7 +6707,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7488,7 +7488,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7603,7 +7603,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7950,7 +7950,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9671,7 +9671,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11803,7 +11803,7 @@ class CabecalhoType(GeneratedsSuper):
     o ocorrer nenhum evento de erro durante o processamento de todo o lote; False - As NFS-e aptas a serem canceladas ser
     ã
     o canceladas, mesmo que ocorram eventos de erro durante processamento do cancelamento de outras NFS-e deste lote.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11936,7 +11936,7 @@ class DetalheType(GeneratedsSuper):
     conter a Chave de uma NFS-e e sua respectiva assinatura de cancelamento.
     ChaveNFe -- Chave da NFS-e a ser cancelada.
     AssinaturaCancelamento -- Assinatura da NFS-e a ser cancelada.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoConsultaCNPJ.py
+++ b/nfselib/paulistana/v03/PedidoConsultaCNPJ.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoConsultaCNPJ_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaCNPJ.py" schemas/nfse/PedidoConsultaCNPJ_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaCNPJ.py" schemas/nfse/PedidoConsultaCNPJ_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1230,7 +1230,7 @@ class PedidoConsultaCNPJ(GeneratedsSuper):
     alho do pedido.
     CNPJContribuinte -- Informe o CNPJ do Contribuinte que se deseja consultar.
     Signature -- Assinatura digital do CNPJ tomador/prestador que gerou a mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1358,7 +1358,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1526,7 +1526,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1667,7 +1667,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1878,7 +1878,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2000,7 +2000,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2218,7 +2218,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2421,7 +2421,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2635,7 +2635,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2778,7 +2778,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3137,7 +3137,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3378,7 +3378,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3657,7 +3657,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3957,7 +3957,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4244,7 +4244,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4368,7 +4368,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4462,7 +4462,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4702,7 +4702,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4970,7 +4970,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5180,7 +5180,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5357,7 +5357,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5491,7 +5491,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5751,7 +5751,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5976,7 +5976,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6312,7 +6312,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6450,7 +6450,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6708,7 +6708,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7489,7 +7489,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7604,7 +7604,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7951,7 +7951,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9672,7 +9672,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11790,7 +11790,7 @@ class CabecalhoType(GeneratedsSuper):
     ã
     o do Schema XML utilizado.
     CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoConsultaLote.py
+++ b/nfselib/paulistana/v03/PedidoConsultaLote.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoConsultaLote_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaLote.py" schemas/nfse/PedidoConsultaLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaLote.py" schemas/nfse/PedidoConsultaLote_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1222,7 +1222,7 @@ class PedidoConsultaLote(GeneratedsSuper):
     ç
     alho do pedido.
     Signature -- Assinatura digital do contribuinte que gerou o lote de RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1338,7 +1338,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1506,7 +1506,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1647,7 +1647,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1858,7 +1858,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1980,7 +1980,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2198,7 +2198,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2401,7 +2401,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2615,7 +2615,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2758,7 +2758,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3117,7 +3117,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3358,7 +3358,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3637,7 +3637,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3937,7 +3937,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4224,7 +4224,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4348,7 +4348,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4442,7 +4442,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4682,7 +4682,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4950,7 +4950,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5160,7 +5160,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5337,7 +5337,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5471,7 +5471,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5731,7 +5731,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5956,7 +5956,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6292,7 +6292,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6430,7 +6430,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6688,7 +6688,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7469,7 +7469,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7584,7 +7584,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7931,7 +7931,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9652,7 +9652,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11773,7 +11773,7 @@ class CabecalhoType(GeneratedsSuper):
     NumeroLote -- Informe o n
     ú
     mero do Lote que deseja consultar.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoConsultaNFePeriodo.py
+++ b/nfselib/paulistana/v03/PedidoConsultaNFePeriodo.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoConsultaNFePeriodo_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaNFePeriodo.py" schemas/nfse/PedidoConsultaNFePeriodo_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoConsultaNFePeriodo.py" schemas/nfse/PedidoConsultaNFePeriodo_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1224,7 +1224,7 @@ class PedidoConsultaNFePeriodo(GeneratedsSuper):
     ç
     alho do pedido.
     Signature -- Assinatura digital do tomador das NFS-e.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1340,7 +1340,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1508,7 +1508,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1649,7 +1649,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1860,7 +1860,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1982,7 +1982,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2200,7 +2200,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2403,7 +2403,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2617,7 +2617,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2760,7 +2760,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3119,7 +3119,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3360,7 +3360,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3639,7 +3639,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3939,7 +3939,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4226,7 +4226,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4350,7 +4350,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4444,7 +4444,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4684,7 +4684,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4952,7 +4952,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5162,7 +5162,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5339,7 +5339,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5473,7 +5473,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5733,7 +5733,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5958,7 +5958,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6294,7 +6294,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6432,7 +6432,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6690,7 +6690,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7471,7 +7471,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7586,7 +7586,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7933,7 +7933,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9428,8 +9428,8 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipa
-    lTomador esteja preenchido.
+    ignorado caso o campo InscricaoMunicipalTom
+    ador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9655,7 +9655,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11798,7 +11798,7 @@ class CabecalhoType(GeneratedsSuper):
     mero da p
     á
     gina que deseja consultar.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoEnvioLoteRPS.py
+++ b/nfselib/paulistana/v03/PedidoEnvioLoteRPS.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoEnvioLoteRPS_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoEnvioLoteRPS.py" schemas/nfse/PedidoEnvioLoteRPS_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoEnvioLoteRPS.py" schemas/nfse/PedidoEnvioLoteRPS_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1226,7 +1226,7 @@ class PedidoEnvioLoteRPS(GeneratedsSuper):
     alho do pedido.
     RPS -- Informe os RPS a serem substituidos por NFS-e.
     Signature -- Assinatura digital do contribuinte que gerou os RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1357,7 +1357,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1525,7 +1525,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1666,7 +1666,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1877,7 +1877,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1999,7 +1999,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2217,7 +2217,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2420,7 +2420,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2634,7 +2634,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2777,7 +2777,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3136,7 +3136,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3377,7 +3377,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3656,7 +3656,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3956,7 +3956,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4243,7 +4243,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4367,7 +4367,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4461,7 +4461,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4701,7 +4701,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4969,7 +4969,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5179,7 +5179,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5356,7 +5356,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5490,7 +5490,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5750,7 +5750,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5975,7 +5975,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6311,7 +6311,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6449,7 +6449,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6707,7 +6707,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7488,7 +7488,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7603,7 +7603,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7950,7 +7950,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9671,7 +9671,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11820,7 +11820,7 @@ class CabecalhoType(GeneratedsSuper):
     í
     odo transmitido (AAAA-MM-DD).
     QtdRPS -- Informe o total de RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoEnvioLoteRPSAsync.py
+++ b/nfselib/paulistana/v03/PedidoEnvioLoteRPSAsync.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoCancelamentoLote.py')
+#   ('-o', 'nfselib/paulistana/v03/PedidoEnvioLoteRPSAsync.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   schemas/nfse/PedidoEnvioLoteRPSAsync_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoLote.py" schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoEnvioLoteRPSAsync.py" schemas/nfse/PedidoEnvioLoteRPSAsync_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1211,27 +1211,32 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoCancelamentoLote(GeneratedsSuper):
-    """PedidoCancelamentoLote -- Schema utilizado para PEDIDO de cancelamento de lote.
+class PedidoEnvioLoteRPS(GeneratedsSuper):
+    """PedidoEnvioLoteRPS -- Schema utilizado para PEDIDO de envio de lote de RPS.
     Este Schema XML
     é
     utilizado pelos prestadores de servi
     ç
-    os cancelarem as NFS-e geradas a partir de um lote de RPS.
+    os para substitui
+    ç
+    ã
+    o em lote de RPS por NFS-e.
     Cabecalho -- Cabe
     ç
-    alho do pedido de cancelamento de lote.
-    Signature -- Assinatura digital do CNPJ emissor dos RPS.
+    alho do pedido.
+    RPS -- Informe os RPS a serem substituidos por NFS-e.
+    Signature -- Assinatura digital do contribuinte que gerou os RPS contidos na mensagem XML.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
+        MemberSpec_('RPS', 'tpRPS', 1, 0, {'maxOccurs': 'unbounded', 'minOccurs': '1', 'name': 'RPS', 'type': 'tpRPS'}, None),
         MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Cabecalho=None, RPS=None, Signature=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1239,53 +1244,59 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Cabecalho = Cabecalho
         self.Cabecalho_nsprefix_ = None
+        if RPS is None:
+            self.RPS = []
+        else:
+            self.RPS = RPS
+        self.RPS_nsprefix_ = None
         self.Signature = Signature
         self.Signature_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoCancelamentoLote)
+                CurrentSubclassModule_, PedidoEnvioLoteRPS)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoCancelamentoLote.subclass:
-            return PedidoCancelamentoLote.subclass(*args_, **kwargs_)
+        if PedidoEnvioLoteRPS.subclass:
+            return PedidoEnvioLoteRPS.subclass(*args_, **kwargs_)
         else:
-            return PedidoCancelamentoLote(*args_, **kwargs_)
+            return PedidoEnvioLoteRPS(*args_, **kwargs_)
     factory = staticmethod(factory)
     def has__content(self):
         if (
             self.Cabecalho is not None or
+            self.RPS or
             self.Signature is not None
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoCancelamentoLote')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoEnvioLoteRPS', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoEnvioLoteRPS')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoCancelamentoLote':
+        if self.original_tagname_ is not None and name_ == 'PedidoEnvioLoteRPS':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoCancelamentoLote')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoEnvioLoteRPS')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoCancelamentoLote', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoEnvioLoteRPS', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoCancelamentoLote'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoEnvioLoteRPS'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoEnvioLoteRPS', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
@@ -1293,6 +1304,9 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         if self.Cabecalho is not None:
             namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
             self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
+        for RPS_ in self.RPS:
+            namespaceprefix_ = self.RPS_nsprefix_ + ':' if (UseCapturedNS_ and self.RPS_nsprefix_) else ''
+            RPS_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='RPS', pretty_print=pretty_print)
         if self.Signature is not None:
             namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
             self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
@@ -1315,12 +1329,17 @@ class PedidoCancelamentoLote(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.Cabecalho = obj_
             obj_.original_tagname_ = 'Cabecalho'
+        elif nodeName_ == 'RPS':
+            obj_ = tpRPS.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.RPS.append(obj_)
+            obj_.original_tagname_ = 'RPS'
         elif nodeName_ == 'Signature':
             obj_ = SignatureType.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
             self.Signature = obj_
             obj_.original_tagname_ = 'Signature'
-# end class PedidoCancelamentoLote
+# end class PedidoEnvioLoteRPS
 
 
 class tpEvento(GeneratedsSuper):
@@ -9424,10 +9443,10 @@ class tpRPS(GeneratedsSuper):
     ç
     o. O conte
     ú
-    do deste campo ser
+    do deste campo
+    ser
     á
-    ignorado caso o campo InscricaoMunicipalTomador esteja pre
-    enchido.
+    ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -11766,25 +11785,56 @@ class X509DataType(GeneratedsSuper):
 class CabecalhoType(GeneratedsSuper):
     """CabecalhoType -- Cabe
     ç
-    alho do pedido de cancelamento de lote.
+    alho do pedido.
     Versao -- Informe a Vers
     ã
     o do Schema XML utilizado.
     CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-    NumeroLote -- Informe o n
-    ú
-    mero do Lote a ser cancelado.
+    transacao -- Informe se os RPS a serem substitu
+    í
+    dos por NFS-e far
+    ã
+    o parte de uma mesma transa
+    ç
+    ã
+    o. True - Os RPS s
+    ó
+    ser
+    ã
+    o substitu
+    í
+    dos por NFS-e se n
+    ã
+    o ocorrer nenhum evento de erro durante o processamento de todo o lote; False - Os RPS v
+    á
+    lidos ser
+    ã
+    o substitu
+    í
+    dos por NFS-e, mesmo que ocorram eventos de erro durante processamento de outros RPS deste lote.
+    dtInicio -- Informe a data de in
+    í
+    cio do per
+    í
+    odo transmitido (AAAA-MM-DD).
+    dtFim -- Informe a data final do per
+    í
+    odo transmitido (AAAA-MM-DD).
+    QtdRPS -- Informe o total de RPS contidos na mensagem XML.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('transacao', 'xs:boolean', 0, 1, {'default': 'true', 'maxOccurs': '1', 'minOccurs': '0', 'name': 'transacao', 'type': 'xs:boolean'}, None),
+        MemberSpec_('dtInicio', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtInicio', 'type': 'xs:date'}, None),
+        MemberSpec_('dtFim', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFim', 'type': 'xs:date'}, None),
+        MemberSpec_('QtdRPS', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdRPS', 'type': 'xs:long'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, NumeroLote=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Versao=None, CPFCNPJRemetente=None, transacao=True, dtInicio=None, dtFim=None, QtdRPS=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -11794,9 +11844,23 @@ class CabecalhoType(GeneratedsSuper):
         self.Versao_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        self.NumeroLote = NumeroLote
-        self.validate_tpNumero(self.NumeroLote)
-        self.NumeroLote_nsprefix_ = None
+        self.transacao = transacao
+        self.transacao_nsprefix_ = None
+        if isinstance(dtInicio, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(dtInicio, '%Y-%m-%d').date()
+        else:
+            initvalue_ = dtInicio
+        self.dtInicio = initvalue_
+        self.dtInicio_nsprefix_ = None
+        if isinstance(dtFim, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(dtFim, '%Y-%m-%d').date()
+        else:
+            initvalue_ = dtFim
+        self.dtFim = initvalue_
+        self.dtFim_nsprefix_ = None
+        self.QtdRPS = QtdRPS
+        self.validate_tpQuantidade(self.QtdRPS)
+        self.QtdRPS_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11808,20 +11872,20 @@ class CabecalhoType(GeneratedsSuper):
         else:
             return CabecalhoType(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def validate_tpNumero(self, value):
+    def validate_tpQuantidade(self, value):
         result = True
-        # Validate type tpNumero, a restriction on xs:long.
+        # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
             if not isinstance(value, int):
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
                 return False
             if not self.gds_validate_simple_patterns(
-                    self.validate_tpNumero_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
+                    self.validate_tpQuantidade_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
                 result = False
         return result
-    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
+    validate_tpQuantidade_patterns_ = [['^([0-9]{1,15})$']]
     def validate_tpVersao(self, value):
         # Validate type tipos:tpVersao, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
@@ -11836,7 +11900,10 @@ class CabecalhoType(GeneratedsSuper):
     def has__content(self):
         if (
             self.CPFCNPJRemetente is not None or
-            self.NumeroLote is not None
+            not self.transacao or
+            self.dtInicio is not None or
+            self.dtFim is not None or
+            self.QtdRPS is not None
         ):
             return True
         else:
@@ -11876,10 +11943,22 @@ class CabecalhoType(GeneratedsSuper):
         if self.CPFCNPJRemetente is not None:
             namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
             self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
-        if self.NumeroLote is not None:
-            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+        if not self.transacao:
+            namespaceprefix_ = self.transacao_nsprefix_ + ':' if (UseCapturedNS_ and self.transacao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+            outfile.write('<%stransacao>%s</%stransacao>%s' % (namespaceprefix_ , self.gds_format_boolean(self.transacao, input_name='transacao'), namespaceprefix_ , eol_))
+        if self.dtInicio is not None:
+            namespaceprefix_ = self.dtInicio_nsprefix_ + ':' if (UseCapturedNS_ and self.dtInicio_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sdtInicio>%s</%sdtInicio>%s' % (namespaceprefix_ , self.gds_format_date(self.dtInicio, input_name='dtInicio'), namespaceprefix_ , eol_))
+        if self.dtFim is not None:
+            namespaceprefix_ = self.dtFim_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFim_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sdtFim>%s</%sdtFim>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFim, input_name='dtFim'), namespaceprefix_ , eol_))
+        if self.QtdRPS is not None:
+            namespaceprefix_ = self.QtdRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdRPS_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sQtdRPS>%s</%sQtdRPS>%s' % (namespaceprefix_ , self.gds_format_integer(self.QtdRPS, input_name='QtdRPS'), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11903,14 +11982,30 @@ class CabecalhoType(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
-        elif nodeName_ == 'NumeroLote' and child_.text:
+        elif nodeName_ == 'transacao':
             sval_ = child_.text
-            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
-            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
-            self.NumeroLote = ival_
-            self.NumeroLote_nsprefix_ = child_.prefix
-            # validate type tpNumero
-            self.validate_tpNumero(self.NumeroLote)
+            ival_ = self.gds_parse_boolean(sval_, node, 'transacao')
+            ival_ = self.gds_validate_boolean(ival_, node, 'transacao')
+            self.transacao = ival_
+            self.transacao_nsprefix_ = child_.prefix
+        elif nodeName_ == 'dtInicio':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.dtInicio = dval_
+            self.dtInicio_nsprefix_ = child_.prefix
+        elif nodeName_ == 'dtFim':
+            sval_ = child_.text
+            dval_ = self.gds_parse_date(sval_)
+            self.dtFim = dval_
+            self.dtFim_nsprefix_ = child_.prefix
+        elif nodeName_ == 'QtdRPS' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'QtdRPS')
+            ival_ = self.gds_validate_integer(ival_, node, 'QtdRPS')
+            self.QtdRPS = ival_
+            self.QtdRPS_nsprefix_ = child_.prefix
+            # validate type tpQuantidade
+            self.validate_tpQuantidade(self.QtdRPS)
 # end class CabecalhoType
 
 
@@ -12342,8 +12437,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEnvioLoteRPS'
+        rootClass = PedidoEnvioLoteRPS
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12374,8 +12469,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEnvioLoteRPS'
+        rootClass = PedidoEnvioLoteRPS
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12420,8 +12515,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEnvioLoteRPS'
+        rootClass = PedidoEnvioLoteRPS
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12448,8 +12543,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'PedidoEnvioLoteRPS'
+        rootClass = PedidoEnvioLoteRPS
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12457,8 +12552,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoCancelamentoLote import *\n\n')
-        sys.stdout.write('import PedidoCancelamentoLote as model_\n\n')
+        sys.stdout.write('#from PedidoEnvioLoteRPSAsync import *\n\n')
+        sys.stdout.write('import PedidoEnvioLoteRPSAsync as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12814,7 +12909,7 @@ __all__ = [
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoCancelamentoLote",
+    "PedidoEnvioLoteRPS",
     "RSAKeyValueType",
     "ReferenceType",
     "SignatureMethodType",

--- a/nfselib/paulistana/v03/PedidoEnvioRPS.py
+++ b/nfselib/paulistana/v03/PedidoEnvioRPS.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoEnvioRPS_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoEnvioRPS.py" schemas/nfse/PedidoEnvioRPS_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoEnvioRPS.py" schemas/nfse/PedidoEnvioRPS_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1226,7 +1226,7 @@ class PedidoEnvioRPS(GeneratedsSuper):
     alho do pedido.
     RPS -- Informe o RPS a ser substituido por NFS-e.
     Signature -- Assinatura digital do contribuinte que gerou o RPS contido da mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1354,7 +1354,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1522,7 +1522,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1663,7 +1663,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1874,7 +1874,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1996,7 +1996,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2214,7 +2214,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2417,7 +2417,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2631,7 +2631,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2774,7 +2774,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3133,7 +3133,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3374,7 +3374,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3653,7 +3653,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3953,7 +3953,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4240,7 +4240,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4364,7 +4364,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4458,7 +4458,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4698,7 +4698,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4966,7 +4966,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5176,7 +5176,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5353,7 +5353,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5487,7 +5487,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5747,7 +5747,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5972,7 +5972,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6308,7 +6308,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6446,7 +6446,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6704,7 +6704,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7485,7 +7485,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7600,7 +7600,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7947,7 +7947,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9668,7 +9668,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11786,7 +11786,7 @@ class CabecalhoType(GeneratedsSuper):
     ã
     o do Schema XML utilizado.
     CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/PedidoInformacoesLote.py
+++ b/nfselib/paulistana/v03/PedidoInformacoesLote.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/PedidoInformacoesLote_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoInformacoesLote.py" schemas/nfse/PedidoInformacoesLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoInformacoesLote.py" schemas/nfse/PedidoInformacoesLote_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1228,7 +1228,7 @@ class PedidoInformacoesLote(GeneratedsSuper):
     ç
     alho do pedido.
     Signature -- Assinatura digital do contribuinte que gerou o lote de RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1344,7 +1344,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1512,7 +1512,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1653,7 +1653,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1864,7 +1864,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1986,7 +1986,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2204,7 +2204,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2407,7 +2407,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2621,7 +2621,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2764,7 +2764,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3123,7 +3123,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3364,7 +3364,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3643,7 +3643,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3943,7 +3943,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4230,7 +4230,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4354,7 +4354,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4448,7 +4448,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4688,7 +4688,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4956,7 +4956,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5166,7 +5166,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5343,7 +5343,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5477,7 +5477,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5737,7 +5737,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5962,7 +5962,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6298,7 +6298,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6436,7 +6436,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6694,7 +6694,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7475,7 +7475,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7590,7 +7590,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7937,7 +7937,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9432,8 +9432,8 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipal
-    Tomador esteja preenchido.
+    ignorado caso o campo InscricaoMunicipalToma
+    dor esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9659,7 +9659,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11800,7 +11800,7 @@ class CabecalhoType(GeneratedsSuper):
     o municipal do prestador de servi
     ç
     os que gerou o lote.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoCancelamentoNFe.py
+++ b/nfselib/paulistana/v03/RetornoCancelamentoNFe.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoCancelamentoNFe_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoCancelamentoNFe.py" schemas/nfse/RetornoCancelamentoNFe_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoCancelamentoNFe.py" schemas/nfse/RetornoCancelamentoNFe_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1227,7 +1227,7 @@ class RetornoCancelamentoNFe(GeneratedsSuper):
     Erro -- Elemento que representa a ocorr
     ê
     ncia de eventos de erro durante o processamento da mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1361,7 +1361,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1529,7 +1529,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1670,7 +1670,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1881,7 +1881,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2003,7 +2003,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2221,7 +2221,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2424,7 +2424,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2638,7 +2638,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2781,7 +2781,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3140,7 +3140,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3381,7 +3381,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3660,7 +3660,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3960,7 +3960,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4247,7 +4247,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4371,7 +4371,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4465,7 +4465,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4705,7 +4705,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4973,7 +4973,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5183,7 +5183,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5360,7 +5360,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5494,7 +5494,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5754,7 +5754,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5979,7 +5979,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6315,7 +6315,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6453,7 +6453,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6711,7 +6711,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7492,7 +7492,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7607,7 +7607,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7954,7 +7954,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9675,7 +9675,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11795,7 +11795,7 @@ class CabecalhoType(GeneratedsSuper):
     Sucesso -- Campo indicativo do sucesso do pedido do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoConsulta.py
+++ b/nfselib/paulistana/v03/RetornoConsulta.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoConsulta_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoConsulta.py" schemas/nfse/RetornoConsulta_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoConsulta.py" schemas/nfse/RetornoConsulta_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1230,7 +1230,7 @@ class RetornoConsulta(GeneratedsSuper):
     NFe -- Elemento NFe - Cada item ser
     á
     um NFS-e.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1379,7 +1379,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1547,7 +1547,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1688,7 +1688,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1899,7 +1899,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2021,7 +2021,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2239,7 +2239,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2442,7 +2442,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2656,7 +2656,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2799,7 +2799,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3158,7 +3158,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3399,7 +3399,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3678,7 +3678,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3978,7 +3978,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4265,7 +4265,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4389,7 +4389,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4483,7 +4483,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4723,7 +4723,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4991,7 +4991,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5201,7 +5201,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5378,7 +5378,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5512,7 +5512,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5772,7 +5772,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5997,7 +5997,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6333,7 +6333,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6471,7 +6471,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6729,7 +6729,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7510,7 +7510,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7625,7 +7625,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7972,7 +7972,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9693,7 +9693,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11813,7 +11813,7 @@ class CabecalhoType(GeneratedsSuper):
     Sucesso -- Campo indicativo do sucesso do pedido do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoConsultaCNPJ.py
+++ b/nfselib/paulistana/v03/RetornoConsultaCNPJ.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoConsultaCNPJ_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoConsultaCNPJ.py" schemas/nfse/RetornoConsultaCNPJ_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoConsultaCNPJ.py" schemas/nfse/RetornoConsultaCNPJ_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1234,7 +1234,7 @@ class RetornoConsultaCNPJ(GeneratedsSuper):
     Erro -- Elemento que representa a ocorr
     ê
     ncia de eventos de erro durante o processamento da mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1383,7 +1383,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1551,7 +1551,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1692,7 +1692,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1903,7 +1903,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2025,7 +2025,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2243,7 +2243,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2446,7 +2446,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2660,7 +2660,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2803,7 +2803,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3162,7 +3162,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3403,7 +3403,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3682,7 +3682,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3982,7 +3982,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4269,7 +4269,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4393,7 +4393,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4487,7 +4487,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4727,7 +4727,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4995,7 +4995,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5205,7 +5205,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5382,7 +5382,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5516,7 +5516,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5776,7 +5776,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6001,7 +6001,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6337,7 +6337,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6475,7 +6475,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6733,7 +6733,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7514,7 +7514,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7629,7 +7629,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7976,7 +7976,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9452,8 +9452,7 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso a tri
-    buta
+    ignorado caso a tributa
     ç
     ã
     o ocorra no munic
@@ -9698,7 +9697,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11818,7 +11817,7 @@ class CabecalhoType(GeneratedsSuper):
     Sucesso -- Campo indicativo do sucesso do pedido do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11946,7 +11945,7 @@ class DetalheType(GeneratedsSuper):
     EmiteNFe -- Campo que indica se o CCM vinculado ao CNPJ consultado emite NFS-e ou n
     ã
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoEnvioLoteRPS.py
+++ b/nfselib/paulistana/v03/RetornoEnvioLoteRPS.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoEnvioLoteRPS_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoEnvioLoteRPS.py" schemas/nfse/RetornoEnvioLoteRPS_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoEnvioLoteRPS.py" schemas/nfse/RetornoEnvioLoteRPS_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1228,7 +1228,7 @@ class RetornoEnvioLoteRPS(GeneratedsSuper):
     ê
     ncia de eventos de erro durante o processamento da mensagem XML.
     ChaveNFeRPS -- Chave da NFS-e e Chave do RPS que esta substitui.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1377,7 +1377,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1545,7 +1545,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1686,7 +1686,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1897,7 +1897,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2019,7 +2019,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2237,7 +2237,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2440,7 +2440,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2654,7 +2654,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2797,7 +2797,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3156,7 +3156,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3397,7 +3397,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3676,7 +3676,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3976,7 +3976,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4263,7 +4263,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4387,7 +4387,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4481,7 +4481,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4721,7 +4721,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4989,7 +4989,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5199,7 +5199,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5376,7 +5376,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5510,7 +5510,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5770,7 +5770,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5995,7 +5995,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6331,7 +6331,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6469,7 +6469,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6727,7 +6727,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7508,7 +7508,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7623,7 +7623,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7970,7 +7970,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9442,8 +9442,8 @@ class tpRPS(GeneratedsSuper):
     os.
     AliquotaServicos -- Informe o valor da al
     í
-    quota. O
-    bs. O conte
+    quota. Obs.
+    O conte
     ú
     do deste campo ser
     á
@@ -9692,7 +9692,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11816,7 +11816,7 @@ class CabecalhoType(GeneratedsSuper):
     ç
     õ
     es sobre o lote processado.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoEnvioLoteRPSAsync.py
+++ b/nfselib/paulistana/v03/RetornoEnvioLoteRPSAsync.py
@@ -11,13 +11,13 @@
 #   ('--member-specs', 'list')
 #   ('--use-getter-setter', 'none')
 #   ('-f', '')
-#   ('-o', 'nfselib/paulistana/v03/PedidoCancelamentoLote.py')
+#   ('-o', 'nfselib/paulistana/v03/RetornoEnvioLoteRPSAsync.py')
 #
 # Command line arguments:
-#   schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   schemas/nfse/RetornoEnvioLoteRPSAsync_v02.xsd
 #
 # Command line:
-#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/PedidoCancelamentoLote.py" schemas/nfse/PedidoCancelamentoLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoEnvioLoteRPSAsync.py" schemas/nfse/RetornoEnvioLoteRPSAsync_v02.xsd
 #
 # Current working directory (os.getcwd()):
 #   nfselib.paulistana
@@ -1008,6 +1008,17 @@ def _cast(typ, value):
 #
 # Start enum classes
 #
+class tpEmissaoGuia(str, Enum):
+    _1='1' # Guia de NFS-e emitidas
+    _2='2' # Guia de NFS-e recebidas (exceto rejeitadas)
+    _3='3' # Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)
+    _4='4' # Guia de NFS-e recebidas aceitas
+    _5='5' # Guia de NFS-e recebidas sem manifestação do tomador
+    _6='6' # Guia de NFS-e recebidas rejeitadas
+    _7='7' # Guia de NFTS emitidas
+    _8='8' # Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)
+
+
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
     
@@ -1162,6 +1173,42 @@ class tpReferencia(str, Enum):
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
 
 
+class tpSituacaoGuia(str, Enum):
+    """tpSituacaoGuia -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es da emiss
+    ã
+    o de guia ass
+    í
+    ncrona.
+    
+    """
+    SOLICITADA='solicitada' # Emissao solicitada (0).
+    INVALIDADA='invalidada' # Emissao invalidada (1).
+    VERIFICADA='verificada' # Emissao verificada (2).
+    PROCESSADA='processada' # Emissao processada (3).
+
+
+class tpSituacaoLote(str, Enum):
+    """tpSituacaoLote -- Tipo referente as poss
+    í
+    veis situa
+    ç
+    õ
+    es do lote ass
+    í
+    ncrono.
+    
+    """
+    ENVIADO='enviado' # Lote enviado (0).
+    INVALIDADO='invalidado' # Lote invalidado (1).
+    VERIFICADO='verificado' # Lote verificado (2).
+    PROCESSADO='processado' # Lote processado (3).
+
+
 class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
@@ -1211,27 +1258,29 @@ class tpTipoRPS(str, Enum):
 #
 # Start data representation classes
 #
-class PedidoCancelamentoLote(GeneratedsSuper):
-    """PedidoCancelamentoLote -- Schema utilizado para PEDIDO de cancelamento de lote.
+class RetornoEnvioLoteRPSAsync(GeneratedsSuper):
+    """RetornoEnvioLoteRPSAsync -- Schema utilizado para RETORNO de Pedidos de Envio de lote de RPS Assincrono.
     Este Schema XML
     é
-    utilizado pelos prestadores de servi
+    utilizado pelo Web Service para informar aos prestadores de servi
     ç
-    os cancelarem as NFS-e geradas a partir de um lote de RPS.
+    os o resultado do pedido de envio de lote de RPS Assincrono.
     Cabecalho -- Cabe
     ç
-    alho do pedido de cancelamento de lote.
-    Signature -- Assinatura digital do CNPJ emissor dos RPS.
+    alho do retorno.
+    Erro -- Elemento que representa a ocorr
+    ê
+    ncia de eventos de erro durante o processamento da mensagem XML.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Cabecalho', 'CabecalhoType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Cabecalho', 'type': 'CabecalhoType'}, None),
-        MemberSpec_('Signature', 'SignatureType', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Signature', 'ref': 'Signature', 'type': 'Signature'}, None),
+        MemberSpec_('Erro', 'tpEventoAsync', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'Erro', 'type': 'tpEventoAsync'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Cabecalho=None, Signature=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Cabecalho=None, Erro=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -1239,53 +1288,56 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Cabecalho = Cabecalho
         self.Cabecalho_nsprefix_ = None
-        self.Signature = Signature
-        self.Signature_nsprefix_ = None
+        if Erro is None:
+            self.Erro = []
+        else:
+            self.Erro = Erro
+        self.Erro_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, PedidoCancelamentoLote)
+                CurrentSubclassModule_, RetornoEnvioLoteRPSAsync)
             if subclass is not None:
                 return subclass(*args_, **kwargs_)
-        if PedidoCancelamentoLote.subclass:
-            return PedidoCancelamentoLote.subclass(*args_, **kwargs_)
+        if RetornoEnvioLoteRPSAsync.subclass:
+            return RetornoEnvioLoteRPSAsync.subclass(*args_, **kwargs_)
         else:
-            return PedidoCancelamentoLote(*args_, **kwargs_)
+            return RetornoEnvioLoteRPSAsync(*args_, **kwargs_)
     factory = staticmethod(factory)
     def has__content(self):
         if (
             self.Cabecalho is not None or
-            self.Signature is not None
+            self.Erro
         ):
             return True
         else:
             return False
-    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('PedidoCancelamentoLote')
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoEnvioLoteRPSAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('RetornoEnvioLoteRPSAsync')
         if imported_ns_def_ is not None:
             namespacedef_ = imported_ns_def_
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.original_tagname_ is not None and name_ == 'PedidoCancelamentoLote':
+        if self.original_tagname_ is not None and name_ == 'RetornoEnvioLoteRPSAsync':
             name_ = self.original_tagname_
         if UseCapturedNS_ and self.ns_prefix_:
             namespaceprefix_ = self.ns_prefix_ + ':'
         showIndent(outfile, level, pretty_print)
         outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
         already_processed = set()
-        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='PedidoCancelamentoLote')
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='RetornoEnvioLoteRPSAsync')
         if self.has__content():
             outfile.write('>%s' % (eol_, ))
-            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='PedidoCancelamentoLote', pretty_print=pretty_print)
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='RetornoEnvioLoteRPSAsync', pretty_print=pretty_print)
             showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
-    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='PedidoCancelamentoLote'):
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='RetornoEnvioLoteRPSAsync'):
         pass
-    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='PedidoCancelamentoLote', fromsubclass_=False, pretty_print=True):
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='RetornoEnvioLoteRPSAsync', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
@@ -1293,9 +1345,9 @@ class PedidoCancelamentoLote(GeneratedsSuper):
         if self.Cabecalho is not None:
             namespaceprefix_ = self.Cabecalho_nsprefix_ + ':' if (UseCapturedNS_ and self.Cabecalho_nsprefix_) else ''
             self.Cabecalho.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Cabecalho', pretty_print=pretty_print)
-        if self.Signature is not None:
-            namespaceprefix_ = self.Signature_nsprefix_ + ':' if (UseCapturedNS_ and self.Signature_nsprefix_) else ''
-            self.Signature.export(outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='Signature', pretty_print=pretty_print)
+        for Erro_ in self.Erro:
+            namespaceprefix_ = self.Erro_nsprefix_ + ':' if (UseCapturedNS_ and self.Erro_nsprefix_) else ''
+            Erro_.export(outfile, level, namespaceprefix_, namespacedef_='', name_='Erro', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -1315,12 +1367,12 @@ class PedidoCancelamentoLote(GeneratedsSuper):
             obj_.build(child_, gds_collector_=gds_collector_)
             self.Cabecalho = obj_
             obj_.original_tagname_ = 'Cabecalho'
-        elif nodeName_ == 'Signature':
-            obj_ = SignatureType.factory(parent_object_=self)
+        elif nodeName_ == 'Erro':
+            obj_ = tpEventoAsync.factory(parent_object_=self)
             obj_.build(child_, gds_collector_=gds_collector_)
-            self.Signature = obj_
-            obj_.original_tagname_ = 'Signature'
-# end class PedidoCancelamentoLote
+            self.Erro.append(obj_)
+            obj_.original_tagname_ = 'Erro'
+# end class RetornoEnvioLoteRPSAsync
 
 
 class tpEvento(GeneratedsSuper):
@@ -1342,8 +1394,8 @@ class tpEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xs:short'}, None),
-        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xs:string'}, None),
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, 3),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, 3),
     ]
@@ -1380,10 +1432,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEvento, a restriction on xs:short.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoEvento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
@@ -1394,10 +1442,6 @@ class tpEvento(GeneratedsSuper):
         result = True
         # Validate type tpDescricaoEvento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 300:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1510,8 +1554,8 @@ class tpCPFCNPJ(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, 4),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, 4),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, 4),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, 4),
     ]
     subclass = None
     superclass = None
@@ -1542,10 +1586,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1556,10 +1596,6 @@ class tpCPFCNPJ(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1651,10 +1687,10 @@ class tpCPFCNPJNIF(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -1691,10 +1727,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -1705,10 +1737,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -1719,10 +1747,6 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1736,12 +1760,8 @@ class tpCPFCNPJNIF(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -1984,10 +2004,10 @@ class tpChaveNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xs:long'}, None),
-        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('NumeroNFe', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroNFe', 'type': 'xsd:long'}, None),
+        MemberSpec_('CodigoVerificacao', ['tpCodigoVerificacao', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoVerificacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ChaveNotaNacional', ['tpChaveNotaNacional', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveNotaNacional', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2024,10 +2044,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2038,10 +2054,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2052,10 +2064,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoVerificacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 8:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoVerificacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2069,10 +2077,6 @@ class tpChaveNFe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -2202,9 +2206,9 @@ class tpChaveRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
-        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xs:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
+        MemberSpec_('SerieRPS', ['tpSerieRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'SerieRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroRPS', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroRPS', 'type': 'xsd:long'}, None),
     ]
     subclass = None
     superclass = None
@@ -2238,10 +2242,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -2252,10 +2252,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpSerieRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 5:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpSerieRPS' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2269,10 +2265,6 @@ class tpChaveRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -2405,10 +2397,10 @@ class tpEnderecoExterior(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xs:string'}, None),
-        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xs:string'}, None),
-        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xs:string'}, None),
-        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cPais', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPais', 'type': 'xsd:string'}, None),
+        MemberSpec_('cEndPost', ['tpCodigoEndPostal', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cEndPost', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCidade', ['tpNomeCidade', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xCidade', 'type': 'xsd:string'}, None),
+        MemberSpec_('xEstProvReg', ['tpEstadoProvinciaRegiao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xEstProvReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -2445,10 +2437,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -2459,10 +2447,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpCodigoEndPostal, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 11:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCodigoEndPostal' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2476,10 +2460,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpNomeCidade, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNomeCidade' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2493,10 +2473,6 @@ class tpEnderecoExterior(GeneratedsSuper):
         result = True
         # Validate type tpEstadoProvinciaRegiao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 60:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEstadoProvinciaRegiao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2619,8 +2595,8 @@ class tpEnderecoNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xs:int'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('cMun', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMun', 'type': 'xsd:int'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, None),
     ]
     subclass = None
     superclass = None
@@ -2651,10 +2627,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2665,10 +2637,6 @@ class tpEnderecoNacional(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -2762,14 +2730,14 @@ class tpEndereco(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xs:string'}, None),
-        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xs:string'}, None),
-        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xs:int'}, None),
-        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xs:string'}, None),
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xs:int'}, None),
+        MemberSpec_('TipoLogradouro', ['tpTipoLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoLogradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Logradouro', ['tpLogradouro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Logradouro', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroEndereco', ['tpNumeroEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('ComplementoEndereco', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ComplementoEndereco', 'type': 'xsd:string'}, None),
+        MemberSpec_('Bairro', ['tpBairro', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Bairro', 'type': 'xsd:string'}, None),
+        MemberSpec_('Cidade', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Cidade', 'type': 'xsd:int'}, None),
+        MemberSpec_('UF', ['tpUF', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'UF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CEP', 'type': 'xsd:int'}, None),
         MemberSpec_('EnderecoExterior', 'tpEnderecoExterior', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoExterior', 'type': 'tpEnderecoExterior'}, None),
     ]
     subclass = None
@@ -2821,10 +2789,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpTipoLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 3:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTipoLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2838,10 +2802,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2855,10 +2815,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2872,10 +2828,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2889,10 +2841,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2906,10 +2854,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -2920,10 +2864,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpUF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpUF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -2937,10 +2877,6 @@ class tpEndereco(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3123,10 +3059,10 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     member_data_items_ = [
         MemberSpec_('endNac', 'tpEnderecoNacional', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endNac', 'type': 'tpEnderecoNacional'}, 5),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 5),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3167,10 +3103,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3184,10 +3116,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3201,10 +3129,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3218,10 +3142,6 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3362,12 +3282,12 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xs:int'}, 6),
+        MemberSpec_('CEP', ['tpCEP', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CEP', 'type': 'xsd:int'}, 6),
         MemberSpec_('endExt', 'tpEnderecoExterior', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'endExt', 'type': 'tpEnderecoExterior'}, 6),
-        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xs:string'}, None),
-        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xs:string'}, None),
-        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xs:string'}, None),
-        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xs:string'}, None),
+        MemberSpec_('xLgr', ['tpLogradouro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xLgr', 'type': 'xsd:string'}, None),
+        MemberSpec_('nro', ['tpNumeroEndereco', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nro', 'type': 'xsd:string'}, None),
+        MemberSpec_('xCpl', ['tpComplementoEndereco', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xCpl', 'type': 'xsd:string'}, None),
+        MemberSpec_('xBairro', ['tpBairro', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xBairro', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3409,10 +3329,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCEP, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCEP_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCEP_patterns_, ))
@@ -3423,10 +3339,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpLogradouro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpLogradouro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3440,10 +3352,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNumeroEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3457,10 +3365,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpComplementoEndereco, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpComplementoEndereco' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3474,10 +3378,6 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpBairro, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpBairro' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -3641,14 +3541,14 @@ class tpInformacoesLote(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xs:long'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoPrestador', ['tpInscricaoMunicipal', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'InscricaoPrestador', 'type': 'xsd:long'}, None),
         MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('DataEnvioLote', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xs:long'}, None),
-        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('DataEnvioLote', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEnvioLote', 'type': 'xsd:string'}, None),
+        MemberSpec_('QtdNotasProcessadas', ['tpQuantidade', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'QtdNotasProcessadas', 'type': 'xsd:long'}, None),
+        MemberSpec_('TempoProcessamento', ['tpTempoProcessamento', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TempoProcessamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorTotalServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalDeducoes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -3666,11 +3566,7 @@ class tpInformacoesLote(GeneratedsSuper):
         self.InscricaoPrestador_nsprefix_ = None
         self.CPFCNPJRemetente = CPFCNPJRemetente
         self.CPFCNPJRemetente_nsprefix_ = None
-        if isinstance(DataEnvioLote, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEnvioLote, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEnvioLote
-        self.DataEnvioLote = initvalue_
+        self.DataEnvioLote = DataEnvioLote
         self.DataEnvioLote_nsprefix_ = None
         self.QtdNotasProcessadas = QtdNotasProcessadas
         self.validate_tpQuantidade(self.QtdNotasProcessadas)
@@ -3699,10 +3595,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -3713,10 +3605,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -3727,10 +3615,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpQuantidade, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpQuantidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpQuantidade_patterns_, ))
@@ -3741,10 +3625,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpTempoProcessamento, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpTempoProcessamento_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpTempoProcessamento_patterns_, ))
@@ -3755,10 +3635,6 @@ class tpInformacoesLote(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -3831,7 +3707,7 @@ class tpInformacoesLote(GeneratedsSuper):
         if self.DataEnvioLote is not None:
             namespaceprefix_ = self.DataEnvioLote_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEnvioLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEnvioLote, input_name='DataEnvioLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEnvioLote>%s</%sDataEnvioLote>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEnvioLote), input_name='DataEnvioLote')), namespaceprefix_ , eol_))
         if self.QtdNotasProcessadas is not None:
             namespaceprefix_ = self.QtdNotasProcessadas_nsprefix_ + ':' if (UseCapturedNS_ and self.QtdNotasProcessadas_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -3884,9 +3760,10 @@ class tpInformacoesLote(GeneratedsSuper):
             self.CPFCNPJRemetente = obj_
             obj_.original_tagname_ = 'CPFCNPJRemetente'
         elif nodeName_ == 'DataEnvioLote':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEnvioLote = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEnvioLote')
+            value_ = self.gds_validate_string(value_, node, 'DataEnvioLote')
+            self.DataEnvioLote = value_
             self.DataEnvioLote_nsprefix_ = child_.prefix
         elif nodeName_ == 'QtdNotasProcessadas' and child_.text:
             sval_ = child_.text
@@ -3941,13 +3818,13 @@ class tpInformacoesPessoa(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'end', 'type': 'tpEnderecoIBSCBS'}, None),
-        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xs:string'}, None),
+        MemberSpec_('email', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'email', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -3992,10 +3869,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -4006,10 +3879,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -4020,10 +3889,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4037,12 +3902,8 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4052,10 +3913,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4069,10 +3926,6 @@ class tpInformacoesPessoa(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4228,7 +4081,7 @@ class tpGRefNFSe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xs:string'}, None),
+        MemberSpec_('refNFSe', ['tpChaveNotaNacional', 'xs:string'], 1, 0, {'maxOccurs': '99', 'minOccurs': '1', 'name': 'refNFSe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4258,10 +4111,6 @@ class tpGRefNFSe(GeneratedsSuper):
         result = True
         # Validate type tpChaveNotaNacional, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpChaveNotaNacional_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpChaveNotaNacional_patterns_, ))
@@ -4446,9 +4295,9 @@ class tpImovelObra(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xs:string'}, None),
-        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xs:string'}, 7),
-        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xs:string'}, 7),
+        MemberSpec_('inscImobFisc', ['tpInscImobFisc', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'inscImobFisc', 'type': 'xsd:string'}, None),
+        MemberSpec_('cCIB', ['tpCCIB', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cCIB', 'type': 'xsd:string'}, 7),
+        MemberSpec_('cObra', ['tpCObra', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cObra', 'type': 'xsd:string'}, 7),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, 7),
     ]
     subclass = None
@@ -4485,10 +4334,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpInscImobFisc, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpInscImobFisc' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4502,10 +4347,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCCIB, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCCIB_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCCIB_patterns_, ))
@@ -4516,10 +4357,6 @@ class tpImovelObra(GeneratedsSuper):
         result = True
         # Validate type tpCObra, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 30:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpCObra' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4690,11 +4527,11 @@ class tpDocumento(GeneratedsSuper):
         MemberSpec_('docFiscalOutro', 'tpDocFiscalOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docFiscalOutro', 'type': 'tpDocFiscalOutro'}, 8),
         MemberSpec_('docOutro', 'tpDocOutro', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'docOutro', 'type': 'tpDocOutro'}, 8),
         MemberSpec_('fornec', 'tpFornecedor', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'fornec', 'type': 'tpFornecedor'}, None),
-        MemberSpec_('dtEmiDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('dtCompDoc', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xs:date'}, None),
-        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xs:int'}, None),
-        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xs:string'}, None),
-        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xs:decimal'}, None),
+        MemberSpec_('dtEmiDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtEmiDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtCompDoc', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtCompDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpReeRepRes', ['tpReeRepRes', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tpReeRepRes', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTpReeRepRes', ['tpXTpReeRepRes', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTpReeRepRes', 'type': 'xsd:string'}, None),
+        MemberSpec_('vlrReeRepRes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'vlrReeRepRes', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -4712,17 +4549,9 @@ class tpDocumento(GeneratedsSuper):
         self.docOutro_nsprefix_ = None
         self.fornec = fornec
         self.fornec_nsprefix_ = None
-        if isinstance(dtEmiDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtEmiDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtEmiDoc
-        self.dtEmiDoc = initvalue_
+        self.dtEmiDoc = dtEmiDoc
         self.dtEmiDoc_nsprefix_ = None
-        if isinstance(dtCompDoc, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtCompDoc, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtCompDoc
-        self.dtCompDoc = initvalue_
+        self.dtCompDoc = dtCompDoc
         self.dtCompDoc_nsprefix_ = None
         self.tpReeRepRes = tpReeRepRes
         self.validate_tpReeRepRes(self.tpReeRepRes)
@@ -4748,12 +4577,8 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpReeRepRes, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 99]
+            enumerations = ['1', '2', '3', '4', '99']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4763,10 +4588,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpXTpReeRepRes, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 150:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTpReeRepRes' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -4780,10 +4601,6 @@ class tpDocumento(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -4858,11 +4675,11 @@ class tpDocumento(GeneratedsSuper):
         if self.dtEmiDoc is not None:
             namespaceprefix_ = self.dtEmiDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtEmiDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtEmiDoc, input_name='dtEmiDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtEmiDoc>%s</%sdtEmiDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtEmiDoc), input_name='dtEmiDoc')), namespaceprefix_ , eol_))
         if self.dtCompDoc is not None:
             namespaceprefix_ = self.dtCompDoc_nsprefix_ + ':' if (UseCapturedNS_ and self.dtCompDoc_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_format_date(self.dtCompDoc, input_name='dtCompDoc'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtCompDoc>%s</%sdtCompDoc>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtCompDoc), input_name='dtCompDoc')), namespaceprefix_ , eol_))
         if self.tpReeRepRes is not None:
             namespaceprefix_ = self.tpReeRepRes_nsprefix_ + ':' if (UseCapturedNS_ and self.tpReeRepRes_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -4910,14 +4727,16 @@ class tpDocumento(GeneratedsSuper):
             self.fornec = obj_
             obj_.original_tagname_ = 'fornec'
         elif nodeName_ == 'dtEmiDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtEmiDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtEmiDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtEmiDoc')
+            self.dtEmiDoc = value_
             self.dtEmiDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtCompDoc':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtCompDoc = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtCompDoc')
+            value_ = self.gds_validate_string(value_, node, 'dtCompDoc')
+            self.dtCompDoc = value_
             self.dtCompDoc_nsprefix_ = child_.prefix
         elif nodeName_ == 'tpReeRepRes' and child_.text:
             sval_ = child_.text
@@ -4954,9 +4773,9 @@ class tpDFeNacional(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xs:int'}, None),
-        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xs:string'}, None),
-        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xs:string'}, None),
+        MemberSpec_('tipoChaveDFe', ['tpTipoChaveDFE', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'tipoChaveDFe', 'type': 'xsd:int'}, None),
+        MemberSpec_('xTipoChaveDFe', ['tpXTipoChaveDFe', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'xTipoChaveDFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('chaveDFe', ['tpChaveDFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'chaveDFe', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -4990,12 +4809,8 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpTipoChaveDFE, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 9]
+            enumerations = ['1', '2', '3', '9']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpTipoChaveDFE' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5005,10 +4820,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpXTipoChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXTipoChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5022,10 +4833,6 @@ class tpDFeNacional(GeneratedsSuper):
         result = True
         # Validate type tpChaveDFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 50:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpChaveDFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5164,9 +4971,9 @@ class tpDocFiscalOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xs:int'}, None),
-        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xs:string'}, None),
-        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xs:string'}, None),
+        MemberSpec_('cMunDocFiscal', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cMunDocFiscal', 'type': 'xsd:int'}, None),
+        MemberSpec_('nDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDocFiscal', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDocFiscal', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDocFiscal', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5200,10 +5007,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -5214,10 +5017,6 @@ class tpDocFiscalOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5341,8 +5140,8 @@ class tpDocOutro(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xs:string'}, None),
-        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xs:string'}, None),
+        MemberSpec_('nDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'nDoc', 'type': 'xsd:string'}, None),
+        MemberSpec_('xDoc', ['tpNumeroDescricaoDocumento', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xDoc', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5373,10 +5172,6 @@ class tpDocOutro(GeneratedsSuper):
         result = True
         # Validate type tpNumeroDescricaoDocumento, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroDescricaoDocumento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5475,11 +5270,11 @@ class tpFornecedor(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xs:string'}, None),
-        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xs:string'}, None),
-        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xs:string'}, None),
-        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xs:int'}, None),
-        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xs:string'}, None),
+        MemberSpec_('CPF', ['tpCPF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPF', 'type': 'xsd:string'}, None),
+        MemberSpec_('CNPJ', ['tpCNPJ', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CNPJ', 'type': 'xsd:string'}, None),
+        MemberSpec_('NIF', ['tpNIF', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NIF', 'type': 'xsd:string'}, None),
+        MemberSpec_('NaoNIF', ['tpNaoNIF', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NaoNIF', 'type': 'xsd:int'}, None),
+        MemberSpec_('xNome', ['tpRazaoSocialObrigatorio', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNome', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -5519,10 +5314,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCPF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCPF_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCPF_patterns_, ))
@@ -5533,10 +5324,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpCNPJ, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCNPJ_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCNPJ_patterns_, ))
@@ -5547,10 +5334,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNIF, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 40:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5564,12 +5347,8 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpNaoNIF, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1, 2]
+            enumerations = ['0', '1', '2']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoNIF' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5579,10 +5358,6 @@ class tpFornecedor(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocialObrigatorio, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocialObrigatorio' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5735,9 +5510,9 @@ class tpAtividadeEvento(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xs:string'}, None),
-        MemberSpec_('dtIniEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xs:date'}, None),
-        MemberSpec_('dtFimEvt', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xs:date'}, None),
+        MemberSpec_('xNomeEvt', ['tpXNomeEvt', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'xNomeEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtIniEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtIniEvt', 'type': 'xsd:string'}, None),
+        MemberSpec_('dtFimEvt', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'dtFimEvt', 'type': 'xsd:string'}, None),
         MemberSpec_('end', 'tpEnderecoSimplesIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'end', 'type': 'tpEnderecoSimplesIBSCBS'}, None),
     ]
     subclass = None
@@ -5751,17 +5526,9 @@ class tpAtividadeEvento(GeneratedsSuper):
         self.xNomeEvt = xNomeEvt
         self.validate_tpXNomeEvt(self.xNomeEvt)
         self.xNomeEvt_nsprefix_ = None
-        if isinstance(dtIniEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtIniEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtIniEvt
-        self.dtIniEvt = initvalue_
+        self.dtIniEvt = dtIniEvt
         self.dtIniEvt_nsprefix_ = None
-        if isinstance(dtFimEvt, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(dtFimEvt, '%Y-%m-%d').date()
-        else:
-            initvalue_ = dtFimEvt
-        self.dtFimEvt = initvalue_
+        self.dtFimEvt = dtFimEvt
         self.dtFimEvt_nsprefix_ = None
         self.end = end
         self.end_nsprefix_ = None
@@ -5780,10 +5547,6 @@ class tpAtividadeEvento(GeneratedsSuper):
         result = True
         # Validate type tpXNomeEvt, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 255:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpXNomeEvt' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -5840,11 +5603,11 @@ class tpAtividadeEvento(GeneratedsSuper):
         if self.dtIniEvt is not None:
             namespaceprefix_ = self.dtIniEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtIniEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtIniEvt, input_name='dtIniEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtIniEvt>%s</%sdtIniEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtIniEvt), input_name='dtIniEvt')), namespaceprefix_ , eol_))
         if self.dtFimEvt is not None:
             namespaceprefix_ = self.dtFimEvt_nsprefix_ + ':' if (UseCapturedNS_ and self.dtFimEvt_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_format_date(self.dtFimEvt, input_name='dtFimEvt'), namespaceprefix_ , eol_))
+            outfile.write('<%sdtFimEvt>%s</%sdtFimEvt>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.dtFimEvt), input_name='dtFimEvt')), namespaceprefix_ , eol_))
         if self.end is not None:
             namespaceprefix_ = self.end_nsprefix_ + ':' if (UseCapturedNS_ and self.end_nsprefix_) else ''
             self.end.export(outfile, level, namespaceprefix_, namespacedef_='', name_='end', pretty_print=pretty_print)
@@ -5871,14 +5634,16 @@ class tpAtividadeEvento(GeneratedsSuper):
             # validate type tpXNomeEvt
             self.validate_tpXNomeEvt(self.xNomeEvt)
         elif nodeName_ == 'dtIniEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtIniEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtIniEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtIniEvt')
+            self.dtIniEvt = value_
             self.dtIniEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'dtFimEvt':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.dtFimEvt = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'dtFimEvt')
+            value_ = self.gds_validate_string(value_, node, 'dtFimEvt')
+            self.dtFimEvt = value_
             self.dtFimEvt_nsprefix_ = child_.prefix
         elif nodeName_ == 'end':
             obj_ = tpEnderecoSimplesIBSCBS.factory(parent_object_=self)
@@ -5960,13 +5725,13 @@ class tpIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xs:int'}, None),
-        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xs:int'}, None),
-        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xs:string'}, None),
-        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xs:int'}, None),
+        MemberSpec_('finNFSe', ['tpFinNFSe', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'finNFSe', 'type': 'xsd:int'}, None),
+        MemberSpec_('indFinal', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indFinal', 'type': 'xsd:int'}, None),
+        MemberSpec_('cIndOp', ['tpCIndOp', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cIndOp', 'type': 'xsd:string'}, None),
+        MemberSpec_('tpOper', ['tpOper', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpOper', 'type': 'xsd:int'}, None),
         MemberSpec_('gRefNFSe', 'tpGRefNFSe', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gRefNFSe', 'type': 'tpGRefNFSe'}, None),
-        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xs:int'}, None),
-        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xs:int'}, None),
+        MemberSpec_('tpEnteGov', ['tpEnteGov', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'tpEnteGov', 'type': 'xsd:int'}, None),
+        MemberSpec_('indDest', ['tpIndDest', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'indDest', 'type': 'xsd:int'}, None),
         MemberSpec_('dest', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'dest', 'type': 'tpInformacoesPessoa'}, None),
         MemberSpec_('valores', 'tpValores', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'valores', 'type': 'tpValores'}, None),
         MemberSpec_('imovelobra', 'tpImovelObra', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'imovelobra', 'type': 'tpImovelObra'}, None),
@@ -6020,12 +5785,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpFinNFSe, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0]
+            enumerations = ['0']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpFinNFSe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6035,12 +5796,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6055,10 +5812,6 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpCIndOp, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCIndOp_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCIndOp_patterns_, ))
@@ -6069,12 +5822,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpOper, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4, 5]
+            enumerations = ['1', '2', '3', '4', '5']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpOper' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6084,12 +5833,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpEnteGov, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [1, 2, 3, 4]
+            enumerations = ['1', '2', '3', '4']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpEnteGov' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6099,12 +5844,8 @@ class tpIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpIndDest, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpIndDest' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -6296,7 +6037,7 @@ class tpGIBSCBS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTrib', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTrib', 'type': 'xsd:string'}, None),
         MemberSpec_('gTribRegular', 'tpGTribRegular', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'gTribRegular', 'type': 'tpGTribRegular'}, None),
     ]
     subclass = None
@@ -6327,10 +6068,6 @@ class tpGIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6434,7 +6171,7 @@ class tpGTribRegular(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xs:string'}, None),
+        MemberSpec_('cClassTribReg', ['tpClassificacaoTributaria', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cClassTribReg', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -6462,10 +6199,6 @@ class tpGTribRegular(GeneratedsSuper):
         result = True
         # Validate type tpClassificacaoTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpClassificacaoTributaria_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpClassificacaoTributaria_patterns_, ))
@@ -6693,45 +6426,45 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Adquirente', 'tpInformacoesPessoa', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Adquirente', 'type': 'tpInformacoesPessoa'}, None),
-        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xs:decimal'}, None),
+        MemberSpec_('ValorBCIBSCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorBCIBSCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercRedCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercRedCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEfetivaCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEfetivaCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoEstadual', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoEstadual', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoMunicipal', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoMunicipal', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDiferimentoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDiferimentoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoClassCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoClassCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPercCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPercCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredPresumidoCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCredPresumidoCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalRegularIBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalRegularIBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorRegularCBS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorRegularCBS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorTotalReeRepRes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalReeRepRes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqEstadualIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqEstadualIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorEstadualBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorEstadualBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorMunicipalIBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMunicipalIBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorAliqCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorAliqCBSCompraGov', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCBSCompraGov', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCBSCompraGov', 'type': 'xsd:decimal'}, None),
     ]
     subclass = None
     superclass = None
@@ -6875,10 +6608,6 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -7848,7 +7577,8 @@ class tpNFe(GeneratedsSuper):
     cula da obra no sistema de cadastro de obras.
     MunicipioPrestacao -- C
     ó
-    digo da cidade do munic
+    digo da cidade do mun
+    ic
     í
     pio da presta
     ç
@@ -7935,67 +7665,67 @@ class tpNFe(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveNFe', 'tpChaveNFe', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveNFe', 'type': 'tpChaveNFe'}, None),
-        MemberSpec_('DataEmissaoNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('DataEmissaoNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroLote', 'type': 'xsd:long'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissaoRPS', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xs:date'}, None),
-        MemberSpec_('DataFatoGeradorNFe', 'xs:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xs:dateTime'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissaoRPS', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataEmissaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataFatoGeradorNFe', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataFatoGeradorNFe', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJPrestador', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJPrestador', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xs:string'}, None),
+        MemberSpec_('RazaoSocialPrestador', ['tpRazaoSocial', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'RazaoSocialPrestador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoPrestador', 'tpEndereco', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'EnderecoPrestador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xs:string'}, None),
-        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('DataCancelamento', 'xs:dateTime', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xs:dateTime'}, None),
-        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xs:string'}, None),
-        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xs:string'}, None),
-        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xs:long'}, None),
-        MemberSpec_('DataQuitacaoGuia', 'xs:date', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xs:date'}, None),
-        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('EmailPrestador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailPrestador', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusNFe', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataCancelamento', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataCancelamento', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoNFe', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoNFe', 'type': 'xsd:string'}, None),
+        MemberSpec_('OpcaoSimples', ['tpOpcaoSimples', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'OpcaoSimples', 'type': 'xsd:string'}, None),
+        MemberSpec_('NumeroGuia', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroGuia', 'type': 'xsd:long'}, None),
+        MemberSpec_('DataQuitacaoGuia', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'DataQuitacaoGuia', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorServicos', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorISS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorISS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCredito', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCredito', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 9),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 9),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
         MemberSpec_('RetornoComplementarIBSCBS', 'tpRetornoComplementarIBSCBS', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RetornoComplementarIBSCBS', 'type': 'tpRetornoComplementarIBSCBS'}, None),
     ]
@@ -8012,11 +7742,7 @@ class tpNFe(GeneratedsSuper):
         self.Assinatura_nsprefix_ = None
         self.ChaveNFe = ChaveNFe
         self.ChaveNFe_nsprefix_ = None
-        if isinstance(DataEmissaoNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataEmissaoNFe
-        self.DataEmissaoNFe = initvalue_
+        self.DataEmissaoNFe = DataEmissaoNFe
         self.DataEmissaoNFe_nsprefix_ = None
         self.NumeroLote = NumeroLote
         self.validate_tpNumero(self.NumeroLote)
@@ -8026,17 +7752,9 @@ class tpNFe(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissaoRPS, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissaoRPS, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissaoRPS
-        self.DataEmissaoRPS = initvalue_
+        self.DataEmissaoRPS = DataEmissaoRPS
         self.DataEmissaoRPS_nsprefix_ = None
-        if isinstance(DataFatoGeradorNFe, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataFatoGeradorNFe, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataFatoGeradorNFe
-        self.DataFatoGeradorNFe = initvalue_
+        self.DataFatoGeradorNFe = DataFatoGeradorNFe
         self.DataFatoGeradorNFe_nsprefix_ = None
         self.CPFCNPJPrestador = CPFCNPJPrestador
         self.CPFCNPJPrestador_nsprefix_ = None
@@ -8051,11 +7769,7 @@ class tpNFe(GeneratedsSuper):
         self.StatusNFe = StatusNFe
         self.validate_tpStatusNFe(self.StatusNFe)
         self.StatusNFe_nsprefix_ = None
-        if isinstance(DataCancelamento, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataCancelamento, '%Y-%m-%dT%H:%M:%S')
-        else:
-            initvalue_ = DataCancelamento
-        self.DataCancelamento = initvalue_
+        self.DataCancelamento = DataCancelamento
         self.DataCancelamento_nsprefix_ = None
         self.TributacaoNFe = TributacaoNFe
         self.validate_tpTributacaoNFe(self.TributacaoNFe)
@@ -8066,11 +7780,7 @@ class tpNFe(GeneratedsSuper):
         self.NumeroGuia = NumeroGuia
         self.validate_tpNumero(self.NumeroGuia)
         self.NumeroGuia_nsprefix_ = None
-        if isinstance(DataQuitacaoGuia, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataQuitacaoGuia, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataQuitacaoGuia
-        self.DataQuitacaoGuia = initvalue_
+        self.DataQuitacaoGuia = DataQuitacaoGuia
         self.DataQuitacaoGuia_nsprefix_ = None
         self.ValorServicos = ValorServicos
         self.validate_tpValor(self.ValorServicos)
@@ -8220,10 +7930,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -8234,10 +7940,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -8249,10 +7951,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8266,10 +7964,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8283,10 +7977,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -8298,10 +7988,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8315,10 +8001,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpOpcaoSimples, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['0', '1', '2', '3', '4', '6']
             if value not in enumerations:
@@ -8330,10 +8012,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -8352,10 +8030,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -8366,10 +8040,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -8383,10 +8053,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -8397,10 +8063,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -8411,10 +8073,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8428,10 +8086,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -8445,10 +8099,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8462,10 +8112,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -8476,12 +8122,8 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -8496,10 +8138,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -8510,10 +8148,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -8524,10 +8158,6 @@ class tpNFe(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -8643,7 +8273,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoNFe is not None:
             namespaceprefix_ = self.DataEmissaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataEmissaoNFe, input_name='DataEmissaoNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoNFe>%s</%sDataEmissaoNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoNFe), input_name='DataEmissaoNFe')), namespaceprefix_ , eol_))
         if self.NumeroLote is not None:
             namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8658,11 +8288,11 @@ class tpNFe(GeneratedsSuper):
         if self.DataEmissaoRPS is not None:
             namespaceprefix_ = self.DataEmissaoRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissaoRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissaoRPS, input_name='DataEmissaoRPS'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissaoRPS>%s</%sDataEmissaoRPS>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissaoRPS), input_name='DataEmissaoRPS')), namespaceprefix_ , eol_))
         if self.DataFatoGeradorNFe is not None:
             namespaceprefix_ = self.DataFatoGeradorNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.DataFatoGeradorNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataFatoGeradorNFe, input_name='DataFatoGeradorNFe'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataFatoGeradorNFe>%s</%sDataFatoGeradorNFe>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataFatoGeradorNFe), input_name='DataFatoGeradorNFe')), namespaceprefix_ , eol_))
         if self.CPFCNPJPrestador is not None:
             namespaceprefix_ = self.CPFCNPJPrestador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJPrestador_nsprefix_) else ''
             self.CPFCNPJPrestador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJPrestador', pretty_print=pretty_print)
@@ -8684,7 +8314,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataCancelamento is not None:
             namespaceprefix_ = self.DataCancelamento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataCancelamento_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataCancelamento, input_name='DataCancelamento'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataCancelamento>%s</%sDataCancelamento>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataCancelamento), input_name='DataCancelamento')), namespaceprefix_ , eol_))
         if self.TributacaoNFe is not None:
             namespaceprefix_ = self.TributacaoNFe_nsprefix_ + ':' if (UseCapturedNS_ and self.TributacaoNFe_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8700,7 +8330,7 @@ class tpNFe(GeneratedsSuper):
         if self.DataQuitacaoGuia is not None:
             namespaceprefix_ = self.DataQuitacaoGuia_nsprefix_ + ':' if (UseCapturedNS_ and self.DataQuitacaoGuia_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_format_date(self.DataQuitacaoGuia, input_name='DataQuitacaoGuia'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataQuitacaoGuia>%s</%sDataQuitacaoGuia>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataQuitacaoGuia), input_name='DataQuitacaoGuia')), namespaceprefix_ , eol_))
         if self.ValorServicos is not None:
             namespaceprefix_ = self.ValorServicos_nsprefix_ + ':' if (UseCapturedNS_ and self.ValorServicos_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -8748,7 +8378,7 @@ class tpNFe(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -8909,9 +8539,10 @@ class tpNFe(GeneratedsSuper):
             self.ChaveNFe = obj_
             obj_.original_tagname_ = 'ChaveNFe'
         elif nodeName_ == 'DataEmissaoNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataEmissaoNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoNFe')
+            self.DataEmissaoNFe = value_
             self.DataEmissaoNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'NumeroLote' and child_.text:
             sval_ = child_.text
@@ -8935,14 +8566,16 @@ class tpNFe(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissaoRPS':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissaoRPS = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissaoRPS')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissaoRPS')
+            self.DataEmissaoRPS = value_
             self.DataEmissaoRPS_nsprefix_ = child_.prefix
         elif nodeName_ == 'DataFatoGeradorNFe':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataFatoGeradorNFe = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataFatoGeradorNFe')
+            value_ = self.gds_validate_string(value_, node, 'DataFatoGeradorNFe')
+            self.DataFatoGeradorNFe = value_
             self.DataFatoGeradorNFe_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJPrestador':
             obj_ = tpCPFCNPJ.factory(parent_object_=self)
@@ -8979,9 +8612,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpStatusNFe
             self.validate_tpStatusNFe(self.StatusNFe)
         elif nodeName_ == 'DataCancelamento':
-            sval_ = child_.text
-            dval_ = self.gds_parse_datetime(sval_)
-            self.DataCancelamento = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataCancelamento')
+            value_ = self.gds_validate_string(value_, node, 'DataCancelamento')
+            self.DataCancelamento = value_
             self.DataCancelamento_nsprefix_ = child_.prefix
         elif nodeName_ == 'TributacaoNFe':
             value_ = child_.text
@@ -9008,9 +8642,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpNumero
             self.validate_tpNumero(self.NumeroGuia)
         elif nodeName_ == 'DataQuitacaoGuia':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataQuitacaoGuia = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataQuitacaoGuia')
+            value_ = self.gds_validate_string(value_, node, 'DataQuitacaoGuia')
+            self.DataQuitacaoGuia = value_
             self.DataQuitacaoGuia_nsprefix_ = child_.prefix
         elif nodeName_ == 'ValorServicos' and child_.text:
             sval_ = child_.text
@@ -9101,10 +8736,10 @@ class tpNFe(GeneratedsSuper):
             # validate type tpValor
             self.validate_tpValor(self.ValorCredito)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -9426,8 +9061,7 @@ class tpRPS(GeneratedsSuper):
     ú
     do deste campo ser
     á
-    ignorado caso o campo InscricaoMunicipalTomador esteja pre
-    enchido.
+    ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.
     InscricaoMunicipalTomador -- Informe a Inscri
     ç
     ã
@@ -9657,52 +9291,52 @@ class tpRPS(GeneratedsSuper):
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Assinatura', ['tpAssinatura', 'xs:base64Binary'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Assinatura', 'type': 'xsd:base64Binary'}, None),
         MemberSpec_('ChaveRPS', 'tpChaveRPS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ChaveRPS', 'type': 'tpChaveRPS'}, None),
-        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('DataEmissao', 'xs:date', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xs:date'}, None),
-        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xs:decimal'}, None),
-        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xs:int'}, None),
-        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ISSRetido', 'xs:boolean', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xs:boolean'}, None),
+        MemberSpec_('TipoRPS', ['tpTipoRPS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TipoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataEmissao', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataEmissao', 'type': 'xsd:string'}, None),
+        MemberSpec_('StatusRPS', ['tpStatusNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'StatusRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('TributacaoRPS', ['tpTributacaoNFe', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'TributacaoRPS', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorDeducoes', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorDeducoes', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorPIS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorPIS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCOFINS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCOFINS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorINSS', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorINSS', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIR', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIR', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorCSLL', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorCSLL', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('CodigoServico', ['tpCodigoServico', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CodigoServico', 'type': 'xsd:int'}, None),
+        MemberSpec_('AliquotaServicos', ['tpAliquota', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'AliquotaServicos', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ISSRetido', 'xsd:string', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ISSRetido', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJTomador', 'tpCPFCNPJNIF', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJTomador', 'type': 'tpCPFCNPJNIF'}, None),
-        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xs:long'}, None),
-        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalTomador', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('InscricaoEstadualTomador', ['tpInscricaoEstadual', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoEstadualTomador', 'type': 'xsd:long'}, None),
+        MemberSpec_('RazaoSocialTomador', ['tpRazaoSocial', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'RazaoSocialTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('EnderecoTomador', 'tpEndereco', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EnderecoTomador', 'type': 'tpEndereco'}, None),
-        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xs:string'}, None),
+        MemberSpec_('EmailTomador', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailTomador', 'type': 'xsd:string'}, None),
         MemberSpec_('CPFCNPJIntermediario', 'tpCPFCNPJ', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CPFCNPJIntermediario', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xs:long'}, None),
-        MemberSpec_('ISSRetidoIntermediario', 'xs:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xs:string'}, None),
-        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xs:string'}, None),
-        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xs:decimal'}, None),
-        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xs:string'}, None),
-        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xs:long'}, None),
-        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xs:long'}, None),
-        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xs:long'}, None),
-        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xs:decimal'}, 10),
-        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xs:decimal'}, None),
-        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xs:int'}, None),
-        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xs:int'}, None),
-        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xs:string'}, None),
-        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xs:string'}, None),
+        MemberSpec_('InscricaoMunicipalIntermediario', ['tpInscricaoMunicipal', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InscricaoMunicipalIntermediario', 'type': 'xsd:long'}, None),
+        MemberSpec_('ISSRetidoIntermediario', 'xsd:string', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ISSRetidoIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('EmailIntermediario', ['tpEmail', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'EmailIntermediario', 'type': 'xsd:string'}, None),
+        MemberSpec_('Discriminacao', ['tpDiscriminacao', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Discriminacao', 'type': 'xsd:string'}, None),
+        MemberSpec_('ValorCargaTributaria', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('PercentualCargaTributaria', ['tpPercentualCargaTributaria', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'PercentualCargaTributaria', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('FonteCargaTributaria', ['tpFonteCargaTributaria', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'FonteCargaTributaria', 'type': 'xsd:string'}, None),
+        MemberSpec_('CodigoCEI', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'CodigoCEI', 'type': 'xsd:long'}, None),
+        MemberSpec_('MatriculaObra', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MatriculaObra', 'type': 'xsd:long'}, None),
+        MemberSpec_('MunicipioPrestacao', ['tpCidade', 'xs:int'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'MunicipioPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('NumeroEncapsulamento', ['tpNumero', 'xs:long'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NumeroEncapsulamento', 'type': 'xsd:long'}, None),
+        MemberSpec_('ValorTotalRecebido', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorTotalRecebido', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorInicialCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorInicialCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorFinalCobrado', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorFinalCobrado', 'type': 'xsd:decimal'}, 10),
+        MemberSpec_('ValorMulta', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorMulta', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorJuros', ['tpValor', 'xs:decimal'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'ValorJuros', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ValorIPI', ['tpValor', 'xs:decimal'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ValorIPI', 'type': 'xsd:decimal'}, None),
+        MemberSpec_('ExigibilidadeSuspensa', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'ExigibilidadeSuspensa', 'type': 'xsd:int'}, None),
+        MemberSpec_('PagamentoParceladoAntecipado', ['tpNaoSim', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'PagamentoParceladoAntecipado', 'type': 'xsd:int'}, None),
+        MemberSpec_('NCM', ['tpCodigoNCM', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'NCM', 'type': 'xsd:string'}, None),
+        MemberSpec_('NBS', ['tpCodigoNBS', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NBS', 'type': 'xsd:string'}, None),
         MemberSpec_('atvEvento', 'tpAtividadeEvento', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'atvEvento', 'type': 'tpAtividadeEvento'}, None),
-        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xs:int'}, None),
-        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xs:string'}, None),
+        MemberSpec_('cLocPrestacao', ['tpCidade', 'xs:int'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cLocPrestacao', 'type': 'xsd:int'}, None),
+        MemberSpec_('cPaisPrestacao', ['tpCodigoPaisISO', 'xs:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'cPaisPrestacao', 'type': 'xsd:string'}, None),
         MemberSpec_('IBSCBS', 'tpIBSCBS', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'IBSCBS', 'type': 'tpIBSCBS'}, None),
     ]
     subclass = None
@@ -9721,11 +9355,7 @@ class tpRPS(GeneratedsSuper):
         self.TipoRPS = TipoRPS
         self.validate_tpTipoRPS(self.TipoRPS)
         self.TipoRPS_nsprefix_ = None
-        if isinstance(DataEmissao, BaseStrType_):
-            initvalue_ = datetime_.datetime.strptime(DataEmissao, '%Y-%m-%d').date()
-        else:
-            initvalue_ = DataEmissao
-        self.DataEmissao = initvalue_
+        self.DataEmissao = DataEmissao
         self.DataEmissao_nsprefix_ = None
         self.StatusRPS = StatusRPS
         self.validate_tpStatusNFe(self.StatusRPS)
@@ -9870,10 +9500,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTipoRPS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['RPS', 'RPS-M', 'RPS-C']
             if value not in enumerations:
@@ -9885,10 +9511,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpStatusNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
             enumerations = ['N', 'C', 'E']
             if value not in enumerations:
@@ -9900,10 +9522,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpTributacaoNFe, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 1:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpTributacaoNFe' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -9917,10 +9535,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpValor, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpValor' % {"value": value, "lineno": lineno} )
@@ -9939,10 +9553,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoServico, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoServico_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoServico_patterns_, ))
@@ -9953,10 +9563,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpAliquota, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpAliquota' % {"value": value, "lineno": lineno} )
@@ -9970,10 +9576,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoMunicipal, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoMunicipal_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoMunicipal_patterns_, ))
@@ -9984,10 +9586,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpInscricaoEstadual, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpInscricaoEstadual_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpInscricaoEstadual_patterns_, ))
@@ -9998,10 +9596,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpRazaoSocial, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpRazaoSocial' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10015,10 +9609,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpEmail, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 75:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpEmail' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10032,10 +9622,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpDiscriminacao, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 2000:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDiscriminacao' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10049,10 +9635,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpPercentualCargaTributaria, a restriction on xs:decimal.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, decimal_.Decimal):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (decimal_.Decimal)' % {"value": value, "lineno": lineno, })
-                return False
             if value < 0:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minInclusive restriction on tpPercentualCargaTributaria' % {"value": value, "lineno": lineno} )
@@ -10066,10 +9648,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpFonteCargaTributaria, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if len(value) > 10:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpFonteCargaTributaria' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10083,10 +9661,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNumero, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpNumero_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
@@ -10097,10 +9671,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCidade, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCidade_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCidade_patterns_, ))
@@ -10111,12 +9681,8 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpNaoSim, a restriction on xs:int.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             value = value
-            enumerations = [0, 1]
+            enumerations = ['0', '1']
             if value not in enumerations:
                 lineno = self.gds_get_node_lineno_()
                 self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd enumeration restriction on tpNaoSim' % {"value" : encode_str_2_3(value), "lineno": lineno} )
@@ -10131,10 +9697,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNCM, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNCM_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNCM_patterns_, ))
@@ -10145,10 +9707,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoNBS, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoNBS_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoNBS_patterns_, ))
@@ -10159,10 +9717,6 @@ class tpRPS(GeneratedsSuper):
         result = True
         # Validate type tpCodigoPaisISO, a restriction on xs:string.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, str):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpCodigoPaisISO_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoPaisISO_patterns_, ))
@@ -10266,7 +9820,7 @@ class tpRPS(GeneratedsSuper):
         if self.DataEmissao is not None:
             namespaceprefix_ = self.DataEmissao_nsprefix_ + ':' if (UseCapturedNS_ and self.DataEmissao_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_format_date(self.DataEmissao, input_name='DataEmissao'), namespaceprefix_ , eol_))
+            outfile.write('<%sDataEmissao>%s</%sDataEmissao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.DataEmissao), input_name='DataEmissao')), namespaceprefix_ , eol_))
         if self.StatusRPS is not None:
             namespaceprefix_ = self.StatusRPS_nsprefix_ + ':' if (UseCapturedNS_ and self.StatusRPS_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
@@ -10310,7 +9864,7 @@ class tpRPS(GeneratedsSuper):
         if self.ISSRetido is not None:
             namespaceprefix_ = self.ISSRetido_nsprefix_ + ':' if (UseCapturedNS_ and self.ISSRetido_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_format_boolean(self.ISSRetido, input_name='ISSRetido'), namespaceprefix_ , eol_))
+            outfile.write('<%sISSRetido>%s</%sISSRetido>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.ISSRetido), input_name='ISSRetido')), namespaceprefix_ , eol_))
         if self.CPFCNPJTomador is not None:
             namespaceprefix_ = self.CPFCNPJTomador_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJTomador_nsprefix_) else ''
             self.CPFCNPJTomador.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJTomador', pretty_print=pretty_print)
@@ -10476,9 +10030,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpTipoRPS
             self.validate_tpTipoRPS(self.TipoRPS)
         elif nodeName_ == 'DataEmissao':
-            sval_ = child_.text
-            dval_ = self.gds_parse_date(sval_)
-            self.DataEmissao = dval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'DataEmissao')
+            value_ = self.gds_validate_string(value_, node, 'DataEmissao')
+            self.DataEmissao = value_
             self.DataEmissao_nsprefix_ = child_.prefix
         elif nodeName_ == 'StatusRPS':
             value_ = child_.text
@@ -10561,10 +10116,10 @@ class tpRPS(GeneratedsSuper):
             # validate type tpAliquota
             self.validate_tpAliquota(self.AliquotaServicos)
         elif nodeName_ == 'ISSRetido':
-            sval_ = child_.text
-            ival_ = self.gds_parse_boolean(sval_, node, 'ISSRetido')
-            ival_ = self.gds_validate_boolean(ival_, node, 'ISSRetido')
-            self.ISSRetido = ival_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'ISSRetido')
+            value_ = self.gds_validate_string(value_, node, 'ISSRetido')
+            self.ISSRetido = value_
             self.ISSRetido_nsprefix_ = child_.prefix
         elif nodeName_ == 'CPFCNPJTomador':
             obj_ = tpCPFCNPJNIF.factory(parent_object_=self)
@@ -10811,7 +10366,7 @@ class tpRPS(GeneratedsSuper):
 class SignatureType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('SignedInfo', 'SignedInfoType', 0, 0, {'name': 'SignedInfo', 'type': 'SignedInfoType'}, None),
         MemberSpec_('SignatureValue', 'SignatureValueType', 0, 0, {'name': 'SignatureValue', 'type': 'SignatureValueType'}, None),
         MemberSpec_('KeyInfo', 'KeyInfoType', 0, 0, {'name': 'KeyInfo', 'type': 'KeyInfoType'}, None),
@@ -10878,7 +10433,7 @@ class SignatureType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -10931,8 +10486,8 @@ class SignatureType(GeneratedsSuper):
 class SignatureValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
-        MemberSpec_('valueOf_', 'xs:base64Binary', 0),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('valueOf_', 'base64Binary', 0),
     ]
     subclass = None
     superclass = None
@@ -10986,7 +10541,7 @@ class SignatureValueType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignatureValueType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignatureValueType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -11014,7 +10569,7 @@ class SignatureValueType(GeneratedsSuper):
 class SignedInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('CanonicalizationMethod', 'CanonicalizationMethodType', 0, 0, {'name': 'CanonicalizationMethod', 'type': 'CanonicalizationMethodType'}, None),
         MemberSpec_('SignatureMethod', 'SignatureMethodType', 0, 0, {'name': 'SignatureMethod', 'type': 'SignatureMethodType'}, None),
         MemberSpec_('Reference', 'ReferenceType', 1, 0, {'maxOccurs': 'unbounded', 'name': 'Reference', 'type': 'ReferenceType'}, None),
@@ -11084,7 +10639,7 @@ class SignedInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='SignedInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='SignedInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11137,12 +10692,12 @@ class SignedInfoType(GeneratedsSuper):
 class ReferenceType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('URI', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'URI'}),
         MemberSpec_('Type', 'xs:anyURI', 0, 1, {'use': 'optional', 'name': 'Type'}),
         MemberSpec_('Transforms', 'TransformsType', 0, 0, {'name': 'Transforms', 'type': 'TransformsType'}, None),
         MemberSpec_('DigestMethod', 'DigestMethodType', 0, 0, {'name': 'DigestMethod', 'type': 'DigestMethodType'}, None),
-        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('DigestValue', ['DigestValueType', 'xs:base64Binary'], 0, 0, {'name': 'DigestValue', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -11217,13 +10772,13 @@ class ReferenceType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='ReferenceType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
         if self.URI is not None and 'URI' not in already_processed:
             already_processed.add('URI')
-            outfile.write(' URI=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.URI), input_name='URI')), ))
+            outfile.write(' URI=%s' % (quote_attrib(self.URI), ))
         if self.Type is not None and 'Type' not in already_processed:
             already_processed.add('Type')
-            outfile.write(' Type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Type), input_name='Type')), ))
+            outfile.write(' Type=%s' % (quote_attrib(self.Type), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='ReferenceType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11386,7 +10941,7 @@ class TransformType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Algorithm', 'xs:anyURI', 0, 0, {'use': 'required', 'name': 'Algorithm'}),
-        MemberSpec_('XPath', 'xs:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xs:string'}, None),
+        MemberSpec_('XPath', 'xsd:string', 1, 1, {'maxOccurs': 'unbounded', 'minOccurs': '0', 'name': 'XPath', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11402,7 +10957,7 @@ class TransformType(GeneratedsSuper):
             self.XPath = []
         else:
             self.XPath = XPath
-        self.XPath_nsprefix_ = None
+        self.XPath_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11447,7 +11002,7 @@ class TransformType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='TransformType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='TransformType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11486,7 +11041,7 @@ class TransformType(GeneratedsSuper):
 class KeyInfoType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Id', 'xs:string', 0, 1, {'use': 'optional', 'name': 'Id'}),
+        MemberSpec_('Id', 'xs:ID', 0, 1, {'use': 'optional', 'name': 'Id'}),
         MemberSpec_('X509Data', 'X509DataType', 0, 0, {'name': 'X509Data', 'type': 'X509DataType'}, None),
     ]
     subclass = None
@@ -11545,7 +11100,7 @@ class KeyInfoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='ds:', name_='KeyInfoType'):
         if self.Id is not None and 'Id' not in already_processed:
             already_processed.add('Id')
-            outfile.write(' Id=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Id), input_name='Id')), ))
+            outfile.write(' Id=%s' % (quote_attrib(self.Id), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='ds:', namespacedef_='', name_='KeyInfoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -11670,7 +11225,7 @@ class KeyValueType(GeneratedsSuper):
 class X509DataType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('X509Certificate', 'xs:base64Binary', 0, 0, {'name': 'X509Certificate', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('X509Certificate', 'xsd:string', 0, 0, {'name': 'X509Certificate', 'type': 'xsd:string'}, None),
     ]
     subclass = None
     superclass = None
@@ -11681,7 +11236,7 @@ class X509DataType(GeneratedsSuper):
         self.parent_object_ = kwargs_.get('parent_object_')
         self.ns_prefix_ = None
         self.X509Certificate = X509Certificate
-        self.X509Certificate_nsprefix_ = None
+        self.X509Certificate_nsprefix_ = "xs"
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11733,7 +11288,7 @@ class X509DataType(GeneratedsSuper):
         if self.X509Certificate is not None:
             namespaceprefix_ = self.X509Certificate_nsprefix_ + ':' if (UseCapturedNS_ and self.X509Certificate_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_format_base64(self.X509Certificate, input_name='X509Certificate'), namespaceprefix_ , eol_))
+            outfile.write('<%sX509Certificate>%s</%sX509Certificate>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.X509Certificate), input_name='X509Certificate')), namespaceprefix_ , eol_))
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11749,42 +11304,445 @@ class X509DataType(GeneratedsSuper):
         pass
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
         if nodeName_ == 'X509Certificate':
-            sval_ = child_.text
-            if sval_ is not None:
-                try:
-                    bval_ = base64.b64decode(sval_)
-                except (TypeError, ValueError) as exp:
-                    raise_parse_error(child_, 'requires base64 encoded string: %s' % exp)
-                bval_ = self.gds_validate_base64(bval_, node, 'X509Certificate')
-            else:
-                bval_ = None
-            self.X509Certificate = bval_
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'X509Certificate')
+            value_ = self.gds_validate_string(value_, node, 'X509Certificate')
+            self.X509Certificate = value_
             self.X509Certificate_nsprefix_ = child_.prefix
 # end class X509DataType
+
+
+class tpEventoAsync(GeneratedsSuper):
+    """Codigo -- C
+    ó
+    digo do evento.
+    Descricao -- Descri
+    ç
+    ã
+    o do evento.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('Codigo', ['tpCodigoEvento', 'xs:short'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Codigo', 'type': 'xsd:short'}, None),
+        MemberSpec_('Descricao', ['tpDescricaoEvento', 'xs:string'], 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'Descricao', 'type': 'xsd:string'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, Codigo=None, Descricao=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.Codigo = Codigo
+        self.validate_tpCodigoEvento(self.Codigo)
+        self.Codigo_nsprefix_ = None
+        self.Descricao = Descricao
+        self.validate_tpDescricaoEvento(self.Descricao)
+        self.Descricao_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpEventoAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpEventoAsync.subclass:
+            return tpEventoAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpEventoAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpCodigoEvento(self, value):
+        result = True
+        # Validate type tpCodigoEvento, a restriction on xs:short.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_tpCodigoEvento_patterns_, value):
+                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpCodigoEvento_patterns_, ))
+                result = False
+        return result
+    validate_tpCodigoEvento_patterns_ = [['^([0-9]{3,4})$']]
+    def validate_tpDescricaoEvento(self, value):
+        result = True
+        # Validate type tpDescricaoEvento, a restriction on xs:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if len(value) > 300:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 0:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpDescricaoEvento' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.Codigo is not None or
+            self.Descricao is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpEventoAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpEventoAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpEventoAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpEventoAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpEventoAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpEventoAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.Codigo is not None:
+            namespaceprefix_ = self.Codigo_nsprefix_ + ':' if (UseCapturedNS_ and self.Codigo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sCodigo>%s</%sCodigo>%s' % (namespaceprefix_ , self.gds_format_integer(self.Codigo, input_name='Codigo'), namespaceprefix_ , eol_))
+        if self.Descricao is not None:
+            namespaceprefix_ = self.Descricao_nsprefix_ + ':' if (UseCapturedNS_ and self.Descricao_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDescricao>%s</%sDescricao>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.Descricao), input_name='Descricao')), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'Codigo' and child_.text:
+            sval_ = child_.text
+            ival_ = self.gds_parse_integer(sval_, node, 'Codigo')
+            ival_ = self.gds_validate_integer(ival_, node, 'Codigo')
+            self.Codigo = ival_
+            self.Codigo_nsprefix_ = child_.prefix
+            # validate type tpCodigoEvento
+            self.validate_tpCodigoEvento(self.Codigo)
+        elif nodeName_ == 'Descricao':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'Descricao')
+            value_ = self.gds_validate_string(value_, node, 'Descricao')
+            self.Descricao = value_
+            self.Descricao_nsprefix_ = child_.prefix
+            # validate type tpDescricaoEvento
+            self.validate_tpDescricaoEvento(self.Descricao)
+# end class tpEventoAsync
+
+
+class tpInformacoesLoteAsync(GeneratedsSuper):
+    """tpInformacoesLoteAsync -- Informa
+    ç
+    õ
+    es do lote processado.
+    NumeroProtocolo -- N
+    ú
+    mero do protocolo do lote.
+    DataRecebimento -- Data/hora de envio do lote.
+    
+    """
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesLoteAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesLoteAsync.subclass:
+            return tpInformacoesLoteAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesLoteAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesLoteAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesLoteAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesLoteAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesLoteAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesLoteAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesLoteAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesLoteAsync
+
+
+class tpInformacoesGuiaAsync(GeneratedsSuper):
+    __hash__ = GeneratedsSuper.__hash__
+    member_data_items_ = [
+        MemberSpec_('NumeroProtocolo', ['tpNumeroProtocoloAsync', 'xsd:string'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroProtocolo', 'type': 'xsd:string'}, None),
+        MemberSpec_('DataRecebimento', 'xsd:dateTime', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'DataRecebimento', 'type': 'xsd:dateTime'}, None),
+    ]
+    subclass = None
+    superclass = None
+    def __init__(self, NumeroProtocolo=None, DataRecebimento=None, gds_collector_=None, **kwargs_):
+        self.gds_collector_ = gds_collector_
+        self.gds_elementtree_node_ = None
+        self.original_tagname_ = None
+        self.parent_object_ = kwargs_.get('parent_object_')
+        self.ns_prefix_ = None
+        self.NumeroProtocolo = NumeroProtocolo
+        self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        self.NumeroProtocolo_nsprefix_ = None
+        if isinstance(DataRecebimento, BaseStrType_):
+            initvalue_ = datetime_.datetime.strptime(DataRecebimento, '%Y-%m-%dT%H:%M:%S')
+        else:
+            initvalue_ = DataRecebimento
+        self.DataRecebimento = initvalue_
+        self.DataRecebimento_nsprefix_ = None
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, tpInformacoesGuiaAsync)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if tpInformacoesGuiaAsync.subclass:
+            return tpInformacoesGuiaAsync.subclass(*args_, **kwargs_)
+        else:
+            return tpInformacoesGuiaAsync(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def validate_tpNumeroProtocoloAsync(self, value):
+        result = True
+        # Validate type tpNumeroProtocoloAsync, a restriction on xsd:string.
+        if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
+            if not isinstance(value, str):
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (str)' % {"value": value, "lineno": lineno, })
+                return False
+            if len(value) > 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd maxLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+            if len(value) < 32:
+                lineno = self.gds_get_node_lineno_()
+                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s does not match xsd minLength restriction on tpNumeroProtocoloAsync' % {"value" : encode_str_2_3(value), "lineno": lineno} )
+                result = False
+        return result
+    def has__content(self):
+        if (
+            self.NumeroProtocolo is not None or
+            self.DataRecebimento is not None
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', pretty_print=True):
+        imported_ns_def_ = GenerateDSNamespaceDefs_.get('tpInformacoesGuiaAsync')
+        if imported_ns_def_ is not None:
+            namespacedef_ = imported_ns_def_
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None and name_ == 'tpInformacoesGuiaAsync':
+            name_ = self.original_tagname_
+        if UseCapturedNS_ and self.ns_prefix_:
+            namespaceprefix_ = self.ns_prefix_ + ':'
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespaceprefix_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self._exportAttributes(outfile, level, already_processed, namespaceprefix_, name_='tpInformacoesGuiaAsync')
+        if self.has__content():
+            outfile.write('>%s' % (eol_, ))
+            self._exportChildren(outfile, level + 1, namespaceprefix_, namespacedef_, name_='tpInformacoesGuiaAsync', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespaceprefix_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='tpInformacoesGuiaAsync'):
+        pass
+    def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='tpInformacoesGuiaAsync', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.NumeroProtocolo is not None:
+            namespaceprefix_ = self.NumeroProtocolo_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroProtocolo_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sNumeroProtocolo>%s</%sNumeroProtocolo>%s' % (namespaceprefix_ , self.gds_encode(self.gds_format_string(quote_xml(self.NumeroProtocolo), input_name='NumeroProtocolo')), namespaceprefix_ , eol_))
+        if self.DataRecebimento is not None:
+            namespaceprefix_ = self.DataRecebimento_nsprefix_ + ':' if (UseCapturedNS_ and self.DataRecebimento_nsprefix_) else ''
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<%sDataRecebimento>%s</%sDataRecebimento>%s' % (namespaceprefix_ , self.gds_format_datetime(self.DataRecebimento, input_name='DataRecebimento'), namespaceprefix_ , eol_))
+    def build(self, node, gds_collector_=None):
+        self.gds_collector_ = gds_collector_
+        if SaveElementTreeNode:
+            self.gds_elementtree_node_ = node
+        already_processed = set()
+        self.ns_prefix_ = node.prefix
+        self._buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self._buildChildren(child, node, nodeName_, gds_collector_=gds_collector_)
+        return self
+    def _buildAttributes(self, node, attrs, already_processed):
+        pass
+    def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
+        if nodeName_ == 'NumeroProtocolo':
+            value_ = child_.text
+            value_ = self.gds_parse_string(value_, node, 'NumeroProtocolo')
+            value_ = self.gds_validate_string(value_, node, 'NumeroProtocolo')
+            self.NumeroProtocolo = value_
+            self.NumeroProtocolo_nsprefix_ = child_.prefix
+            # validate type tpNumeroProtocoloAsync
+            self.validate_tpNumeroProtocoloAsync(self.NumeroProtocolo)
+        elif nodeName_ == 'DataRecebimento':
+            sval_ = child_.text
+            dval_ = self.gds_parse_datetime(sval_)
+            self.DataRecebimento = dval_
+            self.DataRecebimento_nsprefix_ = child_.prefix
+# end class tpInformacoesGuiaAsync
 
 
 class CabecalhoType(GeneratedsSuper):
     """CabecalhoType -- Cabe
     ç
-    alho do pedido de cancelamento de lote.
-    Versao -- Informe a Vers
+    alho do retorno.
+    Versao -- Vers
     ã
     o do Schema XML utilizado.
-    CPFCNPJRemetente -- Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.
-    NumeroLote -- Informe o n
-    ú
-    mero do Lote a ser cancelado.
+    Sucesso -- Campo indicativo do sucesso do pedido do servi
+    ç
+    o.
+    InformacoesLote -- Informa
+    ç
+    õ
+    es sobre o lote processado.
     
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
         MemberSpec_('Versao', 'tipos:tpVersao', 0, 0, {'use': 'required', 'name': 'Versao'}),
-        MemberSpec_('CPFCNPJRemetente', 'tpCPFCNPJ', 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'CPFCNPJRemetente', 'type': 'tpCPFCNPJ'}, None),
-        MemberSpec_('NumeroLote', ['tpNumero', 'xs:long'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'NumeroLote', 'type': 'xs:long'}, None),
+        MemberSpec_('Sucesso', ['tpSucesso', 'xs:boolean'], 0, 0, {'maxOccurs': '1', 'minOccurs': '1', 'name': 'Sucesso', 'type': 'xsd:boolean'}, None),
+        MemberSpec_('InformacoesLote', 'tpInformacoesLoteAsync', 0, 1, {'maxOccurs': '1', 'minOccurs': '0', 'name': 'InformacoesLote', 'type': 'tpInformacoesLoteAsync'}, None),
     ]
     subclass = None
     superclass = None
-    def __init__(self, Versao=None, CPFCNPJRemetente=None, NumeroLote=None, gds_collector_=None, **kwargs_):
+    def __init__(self, Versao=None, Sucesso=None, InformacoesLote=None, gds_collector_=None, **kwargs_):
         self.gds_collector_ = gds_collector_
         self.gds_elementtree_node_ = None
         self.original_tagname_ = None
@@ -11792,11 +11750,11 @@ class CabecalhoType(GeneratedsSuper):
         self.ns_prefix_ = None
         self.Versao = _cast(None, Versao)
         self.Versao_nsprefix_ = None
-        self.CPFCNPJRemetente = CPFCNPJRemetente
-        self.CPFCNPJRemetente_nsprefix_ = None
-        self.NumeroLote = NumeroLote
-        self.validate_tpNumero(self.NumeroLote)
-        self.NumeroLote_nsprefix_ = None
+        self.Sucesso = Sucesso
+        self.validate_tpSucesso(self.Sucesso)
+        self.Sucesso_nsprefix_ = None
+        self.InformacoesLote = InformacoesLote
+        self.InformacoesLote_nsprefix_ = None
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -11808,35 +11766,23 @@ class CabecalhoType(GeneratedsSuper):
         else:
             return CabecalhoType(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def validate_tpNumero(self, value):
+    def validate_tpSucesso(self, value):
         result = True
-        # Validate type tpNumero, a restriction on xs:long.
+        # Validate type tpSucesso, a restriction on xs:boolean.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
-            if not self.gds_validate_simple_patterns(
-                    self.validate_tpNumero_patterns_, value):
-                self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpNumero_patterns_, ))
-                result = False
+            pass
         return result
-    validate_tpNumero_patterns_ = [['^([0-9]{1,12})$']]
     def validate_tpVersao(self, value):
         # Validate type tipos:tpVersao, a restriction on xs:long.
         if value is not None and Validate_simpletypes_ and self.gds_collector_ is not None:
-            if not isinstance(value, int):
-                lineno = self.gds_get_node_lineno_()
-                self.gds_collector_.add_message('Value "%(value)s"%(lineno)s is not of the correct base simple type (int)' % {"value": value, "lineno": lineno, })
-                return False
             if not self.gds_validate_simple_patterns(
                     self.validate_tpVersao_patterns_, value):
                 self.gds_collector_.add_message('Value "%s" does not match xsd pattern restrictions: %s' % (encode_str_2_3(value), self.validate_tpVersao_patterns_, ))
     validate_tpVersao_patterns_ = [['^([0-9]{1,3})$']]
     def has__content(self):
         if (
-            self.CPFCNPJRemetente is not None or
-            self.NumeroLote is not None
+            self.Sucesso is not None or
+            self.InformacoesLote is not None
         ):
             return True
         else:
@@ -11867,19 +11813,19 @@ class CabecalhoType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CabecalhoType'):
         if self.Versao is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            outfile.write(' Versao="%s"' % self.gds_format_integer(self.Versao, input_name='Versao'))
+            outfile.write(' Versao=%s' % (quote_attrib(self.Versao), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CabecalhoType', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
         else:
             eol_ = ''
-        if self.CPFCNPJRemetente is not None:
-            namespaceprefix_ = self.CPFCNPJRemetente_nsprefix_ + ':' if (UseCapturedNS_ and self.CPFCNPJRemetente_nsprefix_) else ''
-            self.CPFCNPJRemetente.export(outfile, level, namespaceprefix_, namespacedef_='', name_='CPFCNPJRemetente', pretty_print=pretty_print)
-        if self.NumeroLote is not None:
-            namespaceprefix_ = self.NumeroLote_nsprefix_ + ':' if (UseCapturedNS_ and self.NumeroLote_nsprefix_) else ''
+        if self.Sucesso is not None:
+            namespaceprefix_ = self.Sucesso_nsprefix_ + ':' if (UseCapturedNS_ and self.Sucesso_nsprefix_) else ''
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%sNumeroLote>%s</%sNumeroLote>%s' % (namespaceprefix_ , self.gds_format_integer(self.NumeroLote, input_name='NumeroLote'), namespaceprefix_ , eol_))
+            outfile.write('<%sSucesso>%s</%sSucesso>%s' % (namespaceprefix_ , self.gds_format_boolean(self.Sucesso, input_name='Sucesso'), namespaceprefix_ , eol_))
+        if self.InformacoesLote is not None:
+            namespaceprefix_ = self.InformacoesLote_nsprefix_ + ':' if (UseCapturedNS_ and self.InformacoesLote_nsprefix_) else ''
+            self.InformacoesLote.export(outfile, level, namespaceprefix_, namespacedef_='', name_='InformacoesLote', pretty_print=pretty_print)
     def build(self, node, gds_collector_=None):
         self.gds_collector_ = gds_collector_
         if SaveElementTreeNode:
@@ -11895,22 +11841,22 @@ class CabecalhoType(GeneratedsSuper):
         value = find_attr_value_('Versao', node)
         if value is not None and 'Versao' not in already_processed:
             already_processed.add('Versao')
-            self.Versao = self.gds_parse_integer(value, node, 'Versao')
+            self.Versao = value
             self.validate_tpVersao(self.Versao)    # validate type tpVersao
     def _buildChildren(self, child_, node, nodeName_, fromsubclass_=False, gds_collector_=None):
-        if nodeName_ == 'CPFCNPJRemetente':
-            obj_ = tpCPFCNPJ.factory(parent_object_=self)
-            obj_.build(child_, gds_collector_=gds_collector_)
-            self.CPFCNPJRemetente = obj_
-            obj_.original_tagname_ = 'CPFCNPJRemetente'
-        elif nodeName_ == 'NumeroLote' and child_.text:
+        if nodeName_ == 'Sucesso':
             sval_ = child_.text
-            ival_ = self.gds_parse_integer(sval_, node, 'NumeroLote')
-            ival_ = self.gds_validate_integer(ival_, node, 'NumeroLote')
-            self.NumeroLote = ival_
-            self.NumeroLote_nsprefix_ = child_.prefix
-            # validate type tpNumero
-            self.validate_tpNumero(self.NumeroLote)
+            ival_ = self.gds_parse_boolean(sval_, node, 'Sucesso')
+            ival_ = self.gds_validate_boolean(ival_, node, 'Sucesso')
+            self.Sucesso = ival_
+            self.Sucesso_nsprefix_ = child_.prefix
+            # validate type tpSucesso
+            self.validate_tpSucesso(self.Sucesso)
+        elif nodeName_ == 'InformacoesLote':
+            obj_ = tpInformacoesLoteAsync.factory(parent_object_=self)
+            obj_.build(child_, gds_collector_=gds_collector_)
+            self.InformacoesLote = obj_
+            obj_.original_tagname_ = 'InformacoesLote'
 # end class CabecalhoType
 
 
@@ -11972,7 +11918,7 @@ class CanonicalizationMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='CanonicalizationMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='CanonicalizationMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12054,7 +12000,7 @@ class SignatureMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='SignatureMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='SignatureMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12136,7 +12082,7 @@ class DigestMethodType(GeneratedsSuper):
     def _exportAttributes(self, outfile, level, already_processed, namespaceprefix_='', name_='DigestMethodType'):
         if self.Algorithm is not None and 'Algorithm' not in already_processed:
             already_processed.add('Algorithm')
-            outfile.write(' Algorithm=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.Algorithm), input_name='Algorithm')), ))
+            outfile.write(' Algorithm=%s' % (quote_attrib(self.Algorithm), ))
     def _exportChildren(self, outfile, level, namespaceprefix_='', namespacedef_='', name_='DigestMethodType', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node, gds_collector_=None):
@@ -12163,8 +12109,8 @@ class DigestMethodType(GeneratedsSuper):
 class RSAKeyValueType(GeneratedsSuper):
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
-        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xs:base64Binary'}, None),
-        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xs:base64Binary'}, None),
+        MemberSpec_('Modulus', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Modulus', 'type': 'xsd:base64Binary'}, None),
+        MemberSpec_('Exponent', ['CryptoBinary', 'xs:base64Binary'], 0, 0, {'name': 'Exponent', 'type': 'xsd:base64Binary'}, None),
     ]
     subclass = None
     superclass = None
@@ -12342,8 +12288,8 @@ def parse(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'RetornoEnvioLoteRPSAsync'
+        rootClass = RetornoEnvioLoteRPSAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     CapturedNsmap_, namespacedefs = get_required_ns_prefix_defs(rootNode)
@@ -12374,8 +12320,8 @@ def parseEtree(inFileName, silence=False, print_warnings=True,
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'RetornoEnvioLoteRPSAsync'
+        rootClass = RetornoEnvioLoteRPSAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if mapping is None:
@@ -12420,8 +12366,8 @@ def parseString(inString, silence=False, print_warnings=True):
     gds_collector = GdsCollector_()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'RetornoEnvioLoteRPSAsync'
+        rootClass = RetornoEnvioLoteRPSAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     if not SaveElementTreeNode:
@@ -12430,7 +12376,7 @@ def parseString(inString, silence=False, print_warnings=True):
         sys.stdout.write('<?xml version="1.0" ?>\n')
         rootObj.export(
             sys.stdout, 0, name_=rootTag,
-            namespacedef_='')
+            namespacedef_='xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"')
     if print_warnings and len(gds_collector.get_messages()) > 0:
         separator = ('-' * 50) + '\n'
         sys.stderr.write(separator)
@@ -12448,8 +12394,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
     rootNode = doc.getroot()
     rootTag, rootClass = get_root_tag(rootNode)
     if rootClass is None:
-        rootTag = 'PedidoCancelamentoLote'
-        rootClass = PedidoCancelamentoLote
+        rootTag = 'RetornoEnvioLoteRPSAsync'
+        rootClass = RetornoEnvioLoteRPSAsync
     rootObj = rootClass.factory()
     rootObj.build(rootNode, gds_collector_=gds_collector)
     # Enable Python to collect the space used by the DOM.
@@ -12457,8 +12403,8 @@ def parseLiteral(inFileName, silence=False, print_warnings=True):
         doc = None
         rootNode = None
     if not silence:
-        sys.stdout.write('#from PedidoCancelamentoLote import *\n\n')
-        sys.stdout.write('import PedidoCancelamentoLote as model_\n\n')
+        sys.stdout.write('#from RetornoEnvioLoteRPSAsync import *\n\n')
+        sys.stdout.write('import RetornoEnvioLoteRPSAsync as model_\n\n')
         sys.stdout.write('rootObj = model_.rootClass(\n')
         rootObj.exportLiteral(sys.stdout, 0, name_=rootTag)
         sys.stdout.write(')\n')
@@ -12773,6 +12719,30 @@ NamespaceToDefMappings_ = {'http://www.prefeitura.sp.gov.br/nfe': [],
                                                 'CT'),
                                                ('tpRPS',
                                                 'schemas/nfse/TiposNFe_v02.xsd',
+                                                'CT'),
+                                               ('tpNumeroProtocoloAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpIncidencia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoLote',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpSituacaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEmissaoGuia',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'ST'),
+                                               ('tpEventoAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesLoteAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
+                                                'CT'),
+                                               ('tpInformacoesGuiaAsync',
+                                                'schemas/nfse/TiposNFeAsync_v02.xsd',
                                                 'CT')],
  'http://www.w3.org/2000/09/xmldsig#': [('CryptoBinary',
                                          'schemas/nfse/xmldsig-core-schema_v02.xsd',
@@ -12814,9 +12784,9 @@ __all__ = [
     "DigestMethodType",
     "KeyInfoType",
     "KeyValueType",
-    "PedidoCancelamentoLote",
     "RSAKeyValueType",
     "ReferenceType",
+    "RetornoEnvioLoteRPSAsync",
     "SignatureMethodType",
     "SignatureType",
     "SignatureValueType",
@@ -12840,6 +12810,7 @@ __all__ = [
     "tpEnderecoNacional",
     "tpEnderecoSimplesIBSCBS",
     "tpEvento",
+    "tpEventoAsync",
     "tpFornecedor",
     "tpGIBSCBS",
     "tpGRefNFSe",
@@ -12847,7 +12818,9 @@ __all__ = [
     "tpGrupoReeRepRes",
     "tpIBSCBS",
     "tpImovelObra",
+    "tpInformacoesGuiaAsync",
     "tpInformacoesLote",
+    "tpInformacoesLoteAsync",
     "tpInformacoesPessoa",
     "tpNFe",
     "tpRPS",

--- a/nfselib/paulistana/v03/RetornoEnvioRPS.py
+++ b/nfselib/paulistana/v03/RetornoEnvioRPS.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoEnvioRPS_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoEnvioRPS.py" schemas/nfse/RetornoEnvioRPS_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoEnvioRPS.py" schemas/nfse/RetornoEnvioRPS_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1228,7 +1228,7 @@ class RetornoEnvioRPS(GeneratedsSuper):
     ê
     ncia de eventos de erro durante o processamento da mensagem XML.
     ChaveNFeRPS -- Chave da NFS-e e Chave do RPS que esta substitui.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1374,7 +1374,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1542,7 +1542,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1683,7 +1683,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1894,7 +1894,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2016,7 +2016,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2234,7 +2234,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2437,7 +2437,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2651,7 +2651,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2794,7 +2794,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3153,7 +3153,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3394,7 +3394,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3673,7 +3673,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3973,7 +3973,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4260,7 +4260,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4384,7 +4384,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4478,7 +4478,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4718,7 +4718,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4986,7 +4986,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5196,7 +5196,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5373,7 +5373,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5507,7 +5507,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5767,7 +5767,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5992,7 +5992,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6328,7 +6328,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6466,7 +6466,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6724,7 +6724,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7505,7 +7505,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7620,7 +7620,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7967,7 +7967,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9441,8 +9441,8 @@ class tpRPS(GeneratedsSuper):
     í
     quota. Obs. O conte
     ú
-    do d
-    este campo ser
+    do deste
+    campo ser
     á
     ignorado caso a tributa
     ç
@@ -9689,7 +9689,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11809,7 +11809,7 @@ class CabecalhoType(GeneratedsSuper):
     Sucesso -- Campo indicativo do sucesso do pedido do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/nfselib/paulistana/v03/RetornoInformacoesLote.py
+++ b/nfselib/paulistana/v03/RetornoInformacoesLote.py
@@ -3,7 +3,7 @@
 
 #
 # Generated  by generateDS.py version 2.44.3.
-# Python 3.10.12 (main, Nov  4 2025, 08:48:33) [GCC 11.4.0]
+# Python 3.14.5 (main, May 10 2026, 10:21:34) [Clang 21.0.0 (clang-2100.0.123.102)]
 #
 # Command line options:
 #   ('--no-namespace-defs', '')
@@ -17,10 +17,10 @@
 #   schemas/nfse/RetornoInformacoesLote_v02.xsd
 #
 # Command line:
-#   /home/cristiano/nfse_paulistana/venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoInformacoesLote.py" schemas/nfse/RetornoInformacoesLote_v02.xsd
+#   /private/tmp/claude-501/-Users-mileo-Documents-kmee-projects-erpbrasil/c2d822bb-806b-4c8a-a82d-034786fd62d1/scratchpad/gds-venv/bin/generateDS --no-namespace-defs --no-dates --member-specs="list" --use-getter-setter="none" -f -o "nfselib/paulistana/v03/RetornoInformacoesLote.py" schemas/nfse/RetornoInformacoesLote_v02.xsd
 #
 # Current working directory (os.getcwd()):
-#   nfse_paulistana
+#   nfselib.paulistana
 #
 
 import sys
@@ -112,7 +112,7 @@ def parsexmlstring_(instring, parser=None, **kwargs):
 #
 
 try:
-    from .generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
+    from generatedsnamespaces import GenerateDSNamespaceDefs as GenerateDSNamespaceDefs_
 except ModulenotfoundExp_ :
     GenerateDSNamespaceDefs_ = {}
 try:
@@ -180,7 +180,7 @@ except ModulenotfoundExp_ as exp:
     except ModulenotfoundExp_ as exp:
         class GeneratedsSuperSuper(object):
             pass
-
+    
     class GeneratedsSuper(GeneratedsSuperSuper):
         __hash__ = object.__hash__
         tzoff_pattern = re_.compile('(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)$')
@@ -266,7 +266,7 @@ except ModulenotfoundExp_ as exp:
             if value.endswith('.'):
                 value += '0'
             return value
-
+    
         def gds_parse_float(self, input_data, node=None, input_name=''):
             try:
                 fval_ = float(input_data)
@@ -696,8 +696,8 @@ except ModulenotfoundExp_ as exp:
                     self.gds_elementtree_node_.sourceline)
             else:
                 return ""
-
-
+    
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -1010,7 +1010,7 @@ def _cast(typ, value):
 #
 class tpEnteGov(str, Enum):
     """tpEnteGov -- Tipo do ente da compra governamental.
-
+    
     """
     _1='1' # União.
     _2='2' # Estados.
@@ -1022,7 +1022,7 @@ class tpFinNFSe(str, Enum):
     """tpFinNFSe -- Indicador da finalidade da emiss
     ã
     o de NFS-e.
-
+    
     """
     _0='0' # 0 = NFS-e regular.
 
@@ -1033,7 +1033,7 @@ class tpIndDest(str, Enum):
     rio dos servi
     ç
     os.
-
+    
     """
     _0='0' # O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).
     _1='1' # O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).
@@ -1046,7 +1046,7 @@ class tpNaoNIF(str, Enum):
     ç
     ã
     o do NIF.
-
+    
     """
     _0='0' # 0 - Não informado na nota de origem;
     _1='1' # 1 - Dispensado do NIF;
@@ -1057,7 +1057,7 @@ class tpNaoSim(str, Enum):
     """tpNaoSim -- Tipo de N
     ã
     o ou Sim.
-
+    
     """
     _0='0' # Não.
     _1='1' # Sim.
@@ -1072,7 +1072,7 @@ class tpOpcaoSimples(str, Enum):
     ç
     õ
     es de escolha pelo Simples.
-
+    
     """
     _0='0' # Não-optante pelo Simples Federal nem Municipal.
     _1='1' # Optante pelo Simples Federal (Alíquota de 1,0%).
@@ -1091,7 +1091,7 @@ class tpOper(str, Enum):
     os sobre bens im
     ó
     veis.
-
+    
     """
     _1='1' # Fornecimento com pagamento posterior.
     _2='2' # Recebimento do pagamento com fornecimento já realizado.
@@ -1143,12 +1143,12 @@ class tpReeRepRes(str, Enum):
     ç
     õ
     es por conta e ordem de terceiro.
-
+    
     """
-    _0_1='01' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
-    _0_2='02' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
-    _0_3='03' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
-    _0_4='04' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
+    _1='1' # 01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+    _2='2' # 02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.
+    _3='3' # 03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.
+    _4='4' # 04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.
     _9_9='99' # 99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro
 
 
@@ -1156,7 +1156,7 @@ class tpReferencia(str, Enum):
     """tpReferencia -- Tipo de refer
     ê
     ncia da nota.
-
+    
     """
     _0='0' # Nota fiscal referenciada para emissão de nota de multa e juros.
     _1='1' # Nota fiscal de pagamento parcelado antecipado.
@@ -1166,7 +1166,7 @@ class tpStatusNFe(str, Enum):
     """tpStatusNFe -- Tipo referente aos poss
     í
     veis status de NFS-e.
-
+    
     """
     N='N' # Normal.
     C='C' # Cancelada.
@@ -1181,7 +1181,7 @@ class tpTipoChaveDFE(str, Enum):
     2 - NF-e.
     3 - CT-e.
     9 - Outro.
-
+    
     """
     _1='1' # NFS-e.
     _2='2' # NF-e.
@@ -1191,7 +1191,7 @@ class tpTipoChaveDFE(str, Enum):
 
 class tpTipoNotaReferenciada(str, Enum):
     """tpTipoNotaReferenciada -- Tipo de nota fiscal referenciada.
-
+    
     """
     _0='0' # NFS-e.
     _1='1' # NFTS.
@@ -1201,7 +1201,7 @@ class tpTipoRPS(str, Enum):
     """tpTipoRPS -- Tipo referente aos poss
     í
     veis tipos de RPS.
-
+    
     """
     RPS='RPS' # Recibo Provisório de Serviços.
     RPSM='RPS-M' # Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).
@@ -1233,7 +1233,7 @@ class RetornoInformacoesLote(GeneratedsSuper):
     Erro -- Elemento que representa a ocorr
     ê
     ncia de eventos de erro durante o processamento da mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1367,7 +1367,7 @@ class tpEvento(GeneratedsSuper):
     o do evento.
     ChaveRPS -- Chave do RPS.
     ChaveNFe -- Chave da NFe.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1535,7 +1535,7 @@ class tpEvento(GeneratedsSuper):
 
 class tpCPFCNPJ(GeneratedsSuper):
     """tpCPFCNPJ -- Tipo que representa um CPF/CNPJ.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1676,7 +1676,7 @@ class tpCPFCNPJ(GeneratedsSuper):
 
 class tpCPFCNPJNIF(GeneratedsSuper):
     """tpCPFCNPJNIF -- Tipo que representa um CPF/CNPJ/NIF.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -1887,7 +1887,7 @@ class tpChaveNFeRPS(GeneratedsSuper):
     ChaveRPS -- Chave do RPS substitu
     í
     do.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2009,7 +2009,7 @@ class tpChaveNFe(GeneratedsSuper):
     ã
     o da NFS-e.
     ChaveNotaNacional -- Chave da Nota Nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2227,7 +2227,7 @@ class tpChaveRPS(GeneratedsSuper):
     NumeroRPS -- N
     ú
     mero do RPS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2430,7 +2430,7 @@ class tpEnderecoExterior(GeneratedsSuper):
     o da cidade no exterior do prestador do servi
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2644,7 +2644,7 @@ class tpEnderecoNacional(GeneratedsSuper):
     """tpEnderecoNacional -- Tipo endere
     ç
     o no nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -2787,7 +2787,7 @@ class tpEndereco(GeneratedsSuper):
     """tpEndereco -- Tipo Endere
     ç
     o.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3146,7 +3146,7 @@ class tpEnderecoIBSCBS(GeneratedsSuper):
     """tpEnderecoIBSCBS -- Tipo Endere
     ç
     o para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3387,7 +3387,7 @@ class tpEnderecoSimplesIBSCBS(GeneratedsSuper):
     """tpEnderecoSimplesIBSCBS -- Tipo Endere
     ç
     o simplificado para o IBSCBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3666,7 +3666,7 @@ class tpInformacoesLote(GeneratedsSuper):
     ç
     õ
     es dos RPS contidos na mensagem XML.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -3966,7 +3966,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
     o eletr
     ô
     nico.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4253,7 +4253,7 @@ class tpInformacoesPessoa(GeneratedsSuper):
 
 class tpGRefNFSe(GeneratedsSuper):
     """tpGRefNFSe -- Grupo com Ids da nota nacional referenciadas, associadas a NFSE.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4377,7 +4377,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
     ressarcimento pelo recebedor, j
     á
     tributados e aqui referenciados.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4471,7 +4471,7 @@ class tpGrupoReeRepRes(GeneratedsSuper):
 
 class tpImovelObra(GeneratedsSuper):
     """tpImovelObra -- Tipo de imovel/obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4711,7 +4711,7 @@ class tpDocumento(GeneratedsSuper):
     lculo do ISS e do IBS e da CBS da NFS-e que est
     á
     sendo emitida (R$).
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -4979,7 +4979,7 @@ class tpDFeNacional(GeneratedsSuper):
     """tpDFeNacional -- Tipo de documento do reposit
     ó
     rio nacional.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5189,7 +5189,7 @@ class tpDocFiscalOutro(GeneratedsSuper):
     ç
     ã
     o do documento fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5366,7 +5366,7 @@ class tpDocOutro(GeneratedsSuper):
     o do documento n
     ã
     o fiscal.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5500,7 +5500,7 @@ class tpFornecedor(GeneratedsSuper):
     õ
     es do fornecedor do documento referenciado.
     xNome -- Nome do fornecedor.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5760,7 +5760,7 @@ class tpAtividadeEvento(GeneratedsSuper):
     end -- Endere
     ç
     o do Evento.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -5985,7 +5985,7 @@ class tpIBSCBS(GeneratedsSuper):
     es sobre o Tipo de Im
     ó
     vel/Obra.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6321,7 +6321,7 @@ class tpGIBSCBS(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6459,7 +6459,7 @@ class tpGTribRegular(GeneratedsSuper):
     o Tribut
     á
     ria do IBS e da CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -6717,7 +6717,7 @@ class tpRetornoComplementarIBSCBS(GeneratedsSuper):
     í
     quota da CBS, referente a compra governamental.
     ValorCBSCompraGov -- Valor da CBS referente a compra governamental
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7498,7 +7498,7 @@ class tpTrib(GeneratedsSuper):
     es relacionadas aos tributos IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7613,7 +7613,7 @@ class tpValores(GeneratedsSuper):
     ç
     õ
     es relacionados aos tributos IBS e CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -7960,7 +7960,7 @@ class tpNFe(GeneratedsSuper):
     es complementares referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -9681,7 +9681,7 @@ class tpRPS(GeneratedsSuper):
     es declaradas pelo emitente referentes ao IBS e
     à
     CBS.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [
@@ -11805,7 +11805,7 @@ class CabecalhoType(GeneratedsSuper):
     ç
     õ
     es do lote consultado.
-
+    
     """
     __hash__ = GeneratedsSuper.__hash__
     member_data_items_ = [

--- a/schemas/nfse/ConsultaGuia_v02.xsd
+++ b/schemas/nfse/ConsultaGuia_v02.xsd
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+    <!--
+    ===========================================================================
+    == ELEMENTOS
+    ===========================================================================
+    -->
+
+    <xsd:element name="PedidoConsultaGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente"    type="tipos:tpCPFCNPJ"              minOccurs="1" maxOccurs="1" />
+                <xsd:element name="InscricaoPrestador"  type="tipos:tpInscricaoMunicipal"   minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Incidencia"          type="async:tpIncidencia"           minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Situacao"            type="tns:tpConsultaSituacaoGuias"  minOccurs="1" maxOccurs="1" />
+                <xsd:element name="TipoEmissao"         type="async:tpEmissaoGuia"          minOccurs="0" maxOccurs="1" />                
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    
+
+    <xsd:element name="RetornoConsultaGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1" />
+                        </xsd:sequence>
+                        <xsd:attribute   name="Versao"  type="tipos:tpVersao" use="required" />
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="Guia" type="tns:tpGuia"          minOccurs="0" maxOccurs="unbounded" />
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded" />
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!--
+    ===========================================================================
+    == TIPOS SIMPLES E DE SUPORTE
+    ===========================================================================
+    -->
+    
+    <xsd:complexType name="tpGuias">
+        <xsd:sequence>
+            <xsd:element name="Guia" type="tns:tpGuia" minOccurs="1" maxOccurs="unbounded"  />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    
+    <xsd:complexType name="tpGuia">
+        <xsd:sequence>
+            <xsd:element name="InscricaoPrestador"  type="tipos:tpInscricaoMunicipal"   minOccurs="1" maxOccurs="1" />
+            <xsd:element name="NumeroGuia"          type="tipos:tpNumero"               minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Incidencia"          type="async:tpIncidencia"           minOccurs="1" maxOccurs="1" />
+            <xsd:element name="ValorTotal"          type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="ValorIss"            type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="ValorTotalPagamento" type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Status"              type="tns:tpStatusGuia"             minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Situacao"            type="tns:tpConsultaSituacaoGuias"  minOccurs="1" maxOccurs="1" />
+            <xsd:element name="Referencia"          type="async:tpEmissaoGuia"          minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataEmissao"         type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataVencimento"      type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataPagamento"       type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataQuitacao"        type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataCancelamento"    type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="LinhaDigitavel"      type="xsd:string"                   minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    
+    <xsd:simpleType name="tpConsultaSituacaoGuias">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Guias pendentes de pagamento</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Guias quitadas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+                <xsd:annotation>
+                    <xsd:documentation>Guias canceladas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+                <xsd:annotation>
+                    <xsd:documentation>Guias pendente de emissao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="tpStatusGuia">
+        <xsd:simpleContent>
+            <xsd:extension base="tns:tpStatusGuiaEnum">
+                <xsd:attribute name="nome" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="tpStatusGuiaEnum">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="0">
+                <xsd:annotation>
+                    <xsd:documentation>Normal</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Cancelada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Quitada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+                <xsd:annotation>
+                    <xsd:documentation>Aproveitada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+                <xsd:annotation>
+                    <xsd:documentation>Alterada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="5">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorRDT</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="6">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorSubstituicao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="7">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorRetificacao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>
+
+<!--
+Normal                  = 0
+Cancelada               = 1
+Quitada                 = 2
+Aproveitada             = 3
+Alterada                = 4
+QuitadaPorRDT           = 5
+QuitadaPorSubstituicao  = 6
+QuitadaPorRetificacao   = 7
+-->

--- a/schemas/nfse/ConsultaSituacaoGuiaAsync_v02.xsd
+++ b/schemas/nfse/ConsultaSituacaoGuiaAsync_v02.xsd
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+
+    <xsd:element name="PedidoConsultaSituacaoGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="NumeroProtocolo" type="async:tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xs:documentation>Número do protocolo da guia.</xs:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+
+    <xsd:element name="RetornoConsultaSituacaoGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xsd:element name="Situacao" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:extension base="xsd:int">
+                                <xsd:attribute name="nome" type="async:tpSituacaoGuia"/>
+                            </xsd:extension>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="NumeroGuia" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Número da guia após processamento.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+
+                <xsd:element name="DataRecebimento"   type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="DataProcessamento" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ResultadoOperacao" type="xsd:string"   minOccurs="0" maxOccurs="1" />
+
+                <xs:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/schemas/nfse/ConsultaSituacaoLoteAsync_v02.xsd
+++ b/schemas/nfse/ConsultaSituacaoLoteAsync_v02.xsd
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+    
+    <xsd:element name="PedidoConsultaSituacaoLote">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="NumeroProtocolo" type="async:tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xs:documentation>Número do protocolo do lote.</xs:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+
+    <xsd:element name="RetornoConsultaSituacaoLote">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                
+                <xsd:element name="Situacao" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:extension base="xsd:int">
+                                <xsd:attribute name="nome" type="async:tpSituacaoLote"/>
+                            </xsd:extension>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="NumeroLote" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Número do lote após processamento.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                
+                <xsd:element name="DataRecebimento"   type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="DataProcessamento" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ResultadoOperacao" type="xsd:string"   minOccurs="0" maxOccurs="1" />
+                
+                <xs:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/schemas/nfse/EmissaoGuiaAsync_v02.xsd
+++ b/schemas/nfse/EmissaoGuiaAsync_v02.xsd
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:sig="http://www.w3.org/2000/09/xmldsig#"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+    <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"        schemaLocation="xmldsig-core-schema_v02.xsd" />
+
+    <xsd:element name="PedidoEmissaoGuiaAsync">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente"   type="tipos:tpCPFCNPJ"            minOccurs="1" maxOccurs="1" />
+                <xsd:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1" />
+                <xsd:element name="TipoEmissaoGuia"    type="async:tpEmissaoGuia"        minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Incidencia"         type="async:tpIncidencia"         minOccurs="1" maxOccurs="1" />
+                <xsd:element name="DataPagamento"      type="xsd:date"                   minOccurs="1" maxOccurs="1" />
+                <xsd:element ref="sig:Signature"       minOccurs="1" maxOccurs="1" />
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="RetornoEmissaoGuiaAsync">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso"         type="tipos:tpSucesso"              minOccurs="1" maxOccurs="1" />
+                            <xsd:element name="InformacoesGuia" type="async:tpInformacoesGuiaAsync" minOccurs="0" maxOccurs="1" />
+                        </xsd:sequence>
+                        <xsd:attribute   name="Versao"          type="tipos:tpVersao" use="required" />
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/schemas/nfse/PedidoEnvioLoteRPSAsync_v02.xsd
+++ b/schemas/nfse/PedidoEnvioLoteRPSAsync_v02.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+	<xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+	<xs:element name="PedidoEnvioLoteRPS">
+		<xs:annotation>
+			<xs:documentation>Schema utilizado para PEDIDO de envio de lote de RPS.</xs:documentation>
+			<xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços para substituição em lote de RPS por NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Cabeçalho do pedido.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="transacao" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+								<xs:annotation>
+									<xs:documentation>Informe se os RPS a serem substituídos por NFS-e farão parte de uma mesma transação. True - Os RPS só serão substituídos por NFS-e se não ocorrer nenhum evento de erro durante o processamento de todo o lote; False - Os RPS válidos serão substituídos por NFS-e, mesmo que ocorram eventos de erro durante processamento de outros RPS deste lote.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtInicio" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data de início do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtFim" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data final do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="QtdRPS"  type="tipos:tpQuantidade" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o total de RPS contidos na mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+							<xs:annotation>
+								<xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="RPS" type="tipos:tpRPS" minOccurs="1" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Informe os RPS a serem substituidos por NFS-e.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Assinatura digital do contribuinte que gerou os RPS contidos na mensagem XML.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/schemas/nfse/RetornoEnvioLoteRPSAsync_v02.xsd
+++ b/schemas/nfse/RetornoEnvioLoteRPSAsync_v02.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema elementFormDefault="unqualified"
+           targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+    <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"        schemaLocation="xmldsig-core-schema_v02.xsd" />
+
+    <xsd:element name="RetornoEnvioLoteRPSAsync">
+        <xsd:annotation>
+            <xsd:documentation>Schema utilizado para RETORNO de Pedidos de Envio de lote de RPS Assincrono.</xsd:documentation>
+            <xsd:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços o resultado do pedido de envio de lote de RPS Assincrono.</xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Cabeçalho do retorno.</xsd:documentation>
+                    </xsd:annotation>
+
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                                <xsd:annotation>
+                                    <xsd:documentation>Campo indicativo do sucesso do pedido do serviço.</xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <xsd:element name="InformacoesLote" type="async:tpInformacoesLoteAsync" minOccurs ="0" maxOccurs ="1">
+                                <xsd:annotation>
+                                    <xsd:documentation>Informações sobre o lote processado.</xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+
+                        <xsd:attribute name="Versao" type="tipos:tpVersao" use="required" >
+                            <xsd:annotation>
+                                <xsd:documentation>Versão do Schema XML utilizado.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/schemas/nfse/TiposNFeAsync_v02.xsd
+++ b/schemas/nfse/TiposNFeAsync_v02.xsd
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema elementFormDefault="unqualified"
+           xmlns="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    <xsd:include schemaLocation="TiposNFe_v02.xsd"/>
+
+    
+    <xsd:complexType name="tpEventoAsync">
+        <xsd:sequence>
+            <xsd:element name="Codigo" type="tpCodigoEvento" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Código do evento.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Descricao" type="tpDescricaoEvento" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Descrição do evento.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="tpInformacoesLoteAsync">
+        <xsd:annotation>
+            <xsd:documentation>Informações do lote processado.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="NumeroProtocolo" type="tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Número do protocolo do lote.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="DataRecebimento" type="xsd:dateTime" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Data/hora de envio do lote.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="tpInformacoesGuiaAsync">
+        <xsd:sequence>
+            <xsd:element name="NumeroProtocolo" type="tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="DataRecebimento" type="xsd:dateTime" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:simpleType name="tpNumeroProtocoloAsync">
+        <xsd:annotation>
+            <xsd:documentation>Tipo do Número de Protocolo.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="32" />
+            <xsd:maxLength value="32" />
+            <xsd:whiteSpace value="collapse" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpIncidencia">
+        <xsd:annotation>
+            <xsd:documentation>Incidência no formato YYYY-MM com ano de 1900 até 2099.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="^((19|20)\d\d)-(0?[1-9]|1[012])$"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <!-- TODO: Should I move it to NFE Main types? -->
+    <xsd:simpleType name="tpSituacaoLote">
+        <xsd:annotation>
+            <xsd:documentation>Tipo referente as possíveis situações do lote assíncrono.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="enviado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote enviado (0).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="invalidado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote invalidado (1).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="verificado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote verificado (2).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="processado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote processado (3).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpSituacaoGuia">
+        <xsd:annotation>
+            <xsd:documentation>Tipo referente as possíveis situações da emissão de guia assíncrona.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="solicitada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao solicitada (0).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="invalidada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao invalidada (1).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="verificada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao verificada (2).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="processada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao processada (3).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpEmissaoGuia">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Guia de NFS-e emitidas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Guia de NFS-e recebidas (exceto rejeitadas)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas aceitas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="5">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas sem manifestação do tomador</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="6">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas rejeitadas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="7">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFTS emitidas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="8">
+              <xsd:annotation>
+                <xsd:documentation>Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/schemas/nfse/TiposNFe_v02.xsd
+++ b/schemas/nfse/TiposNFe_v02.xsd
@@ -750,22 +750,22 @@
 			<xs:documentation>99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:int">
-			<xs:enumeration value="01">
+			<xs:enumeration value="1">
 				<xs:annotation>
 					<xs:documentation>01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="02">
+			<xs:enumeration value="2">
 				<xs:annotation>
 					<xs:documentation>02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="03">
+			<xs:enumeration value="3">
 				<xs:annotation>
 					<xs:documentation>03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
-			<xs:enumeration value="04">
+			<xs:enumeration value="4">
 				<xs:annotation>
 					<xs:documentation>04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
## Contexto

A Prefeitura de SP publicou em **09/01/2026** o pacote oficial `schemas-reformatributaria-v02-4` ([portal do desenvolvedor](https://notadomilhao.sf.prefeitura.sp.gov.br/desenvolvedor/), seção *d) NFS-e – Reforma tributária 2026*). Este PR sincroniza o repositório com esse pacote.

## Mudanças

**Commit 1 — schemas** (`schemas/nfse/`):
- `TiposNFe_v02.xsd`: correção oficial do enum `tpReeRepRes` — valores `"01".."04"` → `"1".."4"` (a base do tipo é `xs:int`; com zeros à esquerda o valor era inválido).
- 7 XSDs novos: serviço **assíncrono** (`PedidoEnvioLoteRPSAsync`, `RetornoEnvioLoteRPSAsync`, `TiposNFeAsync`) e **guias** (`EmissaoGuiaAsync`, `ConsultaGuia`, `ConsultaSituacaoGuiaAsync`, `ConsultaSituacaoLoteAsync`).

**Commit 2 — bindings** (`nfselib/paulistana/v03/`, generateDS 2.44.3, mesmo comando dos headers existentes):
- 15 módulos regenerados (todos embutem os tipos do `TiposNFe_v02.xsd`, então todos pegam o fix do enum — smoke test: `tpReeRepRes = ['1','2','3','4','99']`).
- 6 módulos novos (async + guias), seguindo a convenção de naming sem sufixo de versão do schema.

## Relação com o trabalho da @Escodoo

Complementar ao merged #5 e ao branch `imp-paulista-reforma-tributaria` (@kaynnan): **não** incorpora o patch NT-007 (`RetencaoPisCofins`) porque ele ainda não consta do pacote oficial de schemas — sugiro tratá-lo em PR próprio quando a prefeitura publicar o XSD atualizado, para manter `schemas/` espelhando o oficial. Também não renomeia os módulos existentes (mantém `PedidoEnvioLoteRPS.py`, não `PedidoEnvioLoteRPS_v02.py`) para não quebrar consumidores (`erpbrasil.edoc` importa pelos nomes atuais).

## Validação

- `generateDS.py version 2.44.3` (mesma dos headers v03 existentes)
- Import de todos os 21 módulos OK em Python 3.14
- Sem mudanças em `nfselib/paulistana/v02/` (schema legado intocado)
